### PR TITLE
Updating labeller rbac version

### DIFF
--- a/helm/amd-gpu/templates/labeller.yaml
+++ b/helm/amd-gpu/templates/labeller.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.labeller.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cr-{{ .Chart.Name }}-node-labeller
@@ -8,7 +8,7 @@ rules:
   resources: ["nodes"]
   verbs: ["watch", "get", "list", "update"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: crb-{{ .Chart.Name }}-labeller


### PR DESCRIPTION
`rbac.authorization.k8s.io/v1beta1` is deprecated in [newer kubernetes versions](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122). Updating the api version for the `labeller.yaml` template to `rbac.authorization.k8s.io/v1` for the `ClusterRole` and the `ClusterRoleBinding`