### PR TITLE
Remove reference to deprecated allow-privileged flag for kubelet

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ More information about [ROCm][rocm].
 * [kubeadm capable machines][kubeadm] (if you are using kubeadm to deploy your k8s cluster)
 * [ROCm kernel][rock] ([Installation guide][rocminstall]) or latest AMD GPU Linux driver ([Installation guide][amdgpuinstall])
 * A [Kubernetes deployment][k8sinstall]
-* Ability to run privileged pods (for example the `--allow-privileged=true` flag for kube-apiserver), if the device plugin is deployed via DaemonSet since the device plugin container requires privileged security context to access `/dev/kfd` for device health check
+* If device health checks are enabled, the pods must be allowed to run in privileged mode (for example the `--allow-privileged=true` flag for kube-apiserver), in order to access `/dev/kfd`
 
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ More information about [ROCm][rocm].
 * [kubeadm capable machines][kubeadm] (if you are using kubeadm to deploy your k8s cluster)
 * [ROCm kernel][rock] ([Installation guide][rocminstall]) or latest AMD GPU Linux driver ([Installation guide][amdgpuinstall])
 * A [Kubernetes deployment][k8sinstall]
-* `--allow-privileged=true` for both kube-apiserver and kubelet (only needed if the device plugin is deployed via DaemonSet since the device plugin container requires privileged security context to access `/dev/kfd` for device health check)
+* Ability to run privileged pods (for example the `--allow-privileged=true` flag for kube-apiserver), if the device plugin is deployed via DaemonSet since the device plugin container requires privileged security context to access `/dev/kfd` for device health check
 
 
 ## Limitations
 * This plugin targets Kubernetes v1.18+.
 
 ## Deployment
-The device plugin needs to be run on all the nodes that are equipped with AMD GPU.  The simplest way of doing so is to create a Kubernetes [DaemonSet][ds], which run a copy of a pod on all (or some) Nodes in the cluster.  We have a pre-built Docker image on [DockerHub][dhk8samdgpudp] that you can use for with your DaemonSet.  This repository also have a pre-defined yaml file named `k8s-ds-amdgpu-dp.yaml`.  You can create a DaemonSet in your Kubernetes cluster by running this command:
+The device plugin needs to be run on all the nodes that are equipped with AMD GPU.  The simplest way of doing so is to create a Kubernetes [DaemonSet][ds], which runs a copy of a pod on all (or some) Nodes in the cluster.  We have a pre-built Docker image on [DockerHub][dhk8samdgpudp] that you can use for your DaemonSet.  This repository also has a pre-defined yaml file named `k8s-ds-amdgpu-dp.yaml`.  You can create a DaemonSet in your Kubernetes cluster by running this command:
 ```
 $ kubectl create -f k8s-ds-amdgpu-dp.yaml
 ```
@@ -28,14 +28,14 @@ or directly pull from the web using
 kubectl create -f https://raw.githubusercontent.com/ROCm/k8s-device-plugin/master/k8s-ds-amdgpu-dp.yaml
 ```
 
-If you want to enable the experimental device health check, please use `k8s-ds-amdgpu-dp-health.yaml` **after** `--allow-privileged=true` is set for kube-apiserver and kublet.
+If you want to enable the experimental device health check, please use `k8s-ds-amdgpu-dp-health.yaml` **after** `--allow-privileged=true` is set for kube-apiserver.
 
 ### Helm Chart
 
 If you want to deploy this device plugin using Helm, a [Helm Chart][helmamdgpu] is available via [Artifact Hub][artifacthub].
 
 ## Example workload
-You can restrict work to a node with GPU by adding `resources.limits` to the pod definition.  An example pod definition is provided in `example/pod/alexnet-gpu.yaml`.  This pod runs the timing benchmark for AlexNet on AMD GPU and then go to sleep. You can create the pod by running:
+You can restrict workloads to a node with a GPU by adding `resources.limits` to the pod definition.  An example pod definition is provided in `example/pod/alexnet-gpu.yaml`.  This pod runs the timing benchmark for AlexNet on AMD GPU and then goes to sleep. You can create the pod by running:
 ```
 $ kubectl create -f alexnet-gpu.yaml
 ```


### PR DESCRIPTION
The `--allow-privileged` flag does not exist for kubelet:
https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/

It was removed: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.15.md#node

However I still don't understand why privileged pods are only required if a daemonset is used. How else can the plugin be deployed besides a daemonset, and how does it work when it is unprivileged?

This also fixes some minor language issues.