### PR TITLE
add node_selector_enabled variable

### DIFF
--- a/helm/amd-gpu/README.md
+++ b/helm/amd-gpu/README.md
@@ -26,6 +26,7 @@ Kubernetes: `>= 1.18.0`
 | lbl.image.tag | string | `"labeller-latest"` |  |
 | namespace | string | `"kube-system"` |  |
 | nfd.enabled | bool | `false` |  |
+| node_selector_enabled | bool | `false` |  |
 | node_selector."feature.node.kubernetes.io/pci-0300_1002.present" | string | `"true"` |  |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |

--- a/helm/amd-gpu/templates/deviceplugin-daemonset.yaml
+++ b/helm/amd-gpu/templates/deviceplugin-daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.nfd.enabled }}
+      {{- if .Values.node_selector_enabled }}
       {{- with .Values.node_selector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/amd-gpu/templates/labeller.yaml
+++ b/helm/amd-gpu/templates/labeller.yaml
@@ -39,7 +39,7 @@ spec:
       labels:
         name: amdgpu-lr-ds
     spec:
-      {{- if .Values.nfd.enabled }}
+      {{- if .Values.node_selector_enabled }}
       {{- with .Values.node_selector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/amd-gpu/values.yaml
+++ b/helm/amd-gpu/values.yaml
@@ -31,6 +31,7 @@ tolerations:
   - key: CriticalAddonsOnly
     operator: Exists
 
+node_selector_enabled: false
 node_selector:
   feature.node.kubernetes.io/pci-0300_1002.present: "true"
   kubernetes.io/arch: amd64


### PR DESCRIPTION
This is an alternative to https://github.com/ROCm/k8s-device-plugin/pull/29   @y2kenny 

Default behaviour before: there would be no nodeselectors applied because nfd.enabled is false by default. If you set nfd.enabled=true, then you would get both an installation of NFD, and application of nodeselectors on the daemonsets.

Default behaviour after: there would be no nodeselectors applied because node_selector_enabled is false by default. Installation of NFD and application of nodeselectors can be controlled separately and independently.

Anyone who previously set nfd.enabled=true and got both a NFD installation and nodeselectors will now need to also set node_selector_enabled=true to continue applying the same nodeselector as before.

It's a bit weird but seems like a less disruptive way to un-overload the nfd.enabled variable.