### PR TITLE
Create Dockerfile for building images with ubi base image

### DIFF
--- a/ubi-dp.Dockerfile
+++ b/ubi-dp.Dockerfile
@@ -1,0 +1,48 @@
+# Copyright 2022 Advanced Micro Devices, Inc.  All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+FROM registry.access.redhat.com/ubi9/ubi:latest as builder
+USER root
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/ && \
+    dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/ && \
+    rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official && \
+    dnf install git pkgconfig gcc gcc-c++ make glibc-devel binutils libdrm-devel hwloc-devel wget tar gzip -y && \
+    dnf clean all
+RUN wget https://golang.org/dl/go1.23.3.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.23.3.linux-amd64.tar.gz && \
+    rm go1.23.3.linux-amd64.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH="/go"
+RUN mkdir -p /go/src/github.com/ROCm/k8s-device-plugin
+ADD . /go/src/github.com/ROCm/k8s-device-plugin
+WORKDIR /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-device-plugin
+RUN go install \
+    -ldflags="-X main.gitDescribe=$(git -C /go/src/github.com/ROCm/k8s-device-plugin/ describe --always --long --dirty)"
+
+FROM registry.access.redhat.com/ubi9/ubi-init:9.4
+LABEL \
+    org.opencontainers.image.source="https://github.com/ROCm/k8s-device-plugin" \
+    org.opencontainers.image.authors="Yan Sun <Yan.Sun3@amd.com>" \
+    org.opencontainers.image.vendor="Advanced Micro Devices, Inc." \
+    org.opencontainers.image.licenses="Apache-2.0"
+RUN dnf install -y ca-certificates libdrm && \
+    rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official && \
+    dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/ && \
+    dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/ && \
+    dnf install -y hwloc && \
+    dnf clean all
+WORKDIR /root/
+COPY --from=builder /go/bin/k8s-device-plugin .
+CMD ["./k8s-device-plugin", "-logtostderr=true", "-stderrthreshold=INFO", "-v=5"]

--- a/ubi-dp.Dockerfile
+++ b/ubi-dp.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 Advanced Micro Devices, Inc.  All rights reserved.
+# Copyright 2024 Advanced Micro Devices, Inc.  All rights reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/ubi-labeller.Dockerfile
+++ b/ubi-labeller.Dockerfile
@@ -1,0 +1,45 @@
+# Copyright 2022 Advanced Micro Devices, Inc.  All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+FROM registry.access.redhat.com/ubi9/ubi:latest as builder
+USER root
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/ && \
+    dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/ && \
+    rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official && \
+    dnf install git pkgconfig gcc gcc-c++ make glibc-devel binutils libdrm-devel wget tar gzip -y && \
+    dnf clean all
+RUN wget https://golang.org/dl/go1.23.3.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.23.3.linux-amd64.tar.gz && \
+    rm go1.23.3.linux-amd64.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH="/go"
+RUN mkdir -p /go/src/github.com/ROCm/k8s-device-plugin
+ADD . /go/src/github.com/ROCm/k8s-device-plugin
+WORKDIR /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller
+RUN go install \
+    -ldflags="-X main.gitDescribe=$(git -C /go/src/github.com/ROCm/k8s-device-plugin/ describe --always --long --dirty)"
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
+LABEL \
+    org.opencontainers.image.source="https://github.com/ROCm/k8s-device-plugin" \
+    org.opencontainers.image.authors="Yan Sun <Yan.Sun3@amd.com>" \
+    org.opencontainers.image.vendor="Advanced Micro Devices, Inc." \
+    org.opencontainers.image.licenses="Apache-2.0"
+
+RUN microdnf install -y ca-certificates libdrm && \
+    microdnf clean all
+
+WORKDIR /root/
+COPY --from=builder /go/bin/k8s-node-labeller .
+CMD ["./k8s-node-labeller"]

--- a/ubi-labeller.Dockerfile
+++ b/ubi-labeller.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 Advanced Micro Devices, Inc.  All rights reserved.
+# Copyright 2024 Advanced Micro Devices, Inc.  All rights reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.


### PR DESCRIPTION
RedHat team has requested to use ubi based image to execute device plugin and node labeller pod within OpenShift cluster, creating 2 dockerfiles to build images based on ubi base image.

Verified on OpenSift cluster:
```
[core@openshift ~]$ oc get node -ojson | grep amd.com
                    "amd.com/gpu.device-id": "740f",
                    "amd.com/gpu.family": "AI",
                    "amd.com/gpu.simd-count": "416",
                    "amd.com/gpu.vram": "64G",
                    "beta.amd.com/gpu.device-id": "740f",
                    "beta.amd.com/gpu.device-id.740f": "1",
                    "beta.amd.com/gpu.family": "AI",
                    "beta.amd.com/gpu.family.AI": "1",
                    "beta.amd.com/gpu.simd-count": "416",
                    "beta.amd.com/gpu.simd-count.104": "1",
                    "beta.amd.com/gpu.simd-count.416": "1",
                    "beta.amd.com/gpu.vram": "64G",
                    "beta.amd.com/gpu.vram.64G": "1",
                    "amd.com/gpu": "1",
                    "amd.com/gpu": "1",
```