### PR TITLE
Add license to ubi based images for certification request

### DIFF
--- a/ubi-dp.Dockerfile
+++ b/ubi-dp.Dockerfile
@@ -36,13 +36,15 @@ LABEL \
     org.opencontainers.image.authors="Yan Sun <Yan.Sun3@amd.com>" \
     org.opencontainers.image.vendor="Advanced Micro Devices, Inc." \
     org.opencontainers.image.licenses="Apache-2.0"
-RUN dnf install -y ca-certificates libdrm && \
+RUN mkdir -p /licenses && \
+    dnf install -y ca-certificates libdrm && \
     rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official && \
     dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/ && \
     dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/ && \
     dnf install -y hwloc && \
     dnf clean all
+ADD ./LICENSE /licenses/LICENSE
 WORKDIR /root/
 COPY --from=builder /go/bin/k8s-device-plugin .
 CMD ["./k8s-device-plugin", "-logtostderr=true", "-stderrthreshold=INFO", "-v=5"]

--- a/ubi-labeller.Dockerfile
+++ b/ubi-labeller.Dockerfile
@@ -37,9 +37,10 @@ LABEL \
     org.opencontainers.image.vendor="Advanced Micro Devices, Inc." \
     org.opencontainers.image.licenses="Apache-2.0"
 
-RUN microdnf install -y ca-certificates libdrm && \
+RUN mkdir -p /licenses && \
+    microdnf install -y ca-certificates libdrm && \
     microdnf clean all
-
+ADD ./LICENSE /licenses/LICENSE
 WORKDIR /root/
 COPY --from=builder /go/bin/k8s-node-labeller .
 CMD ["./k8s-node-labeller"]


### PR DESCRIPTION
RedHat Operator certification test requires to add license file to the image.

Modifying 2 ubi based images dockerfiles to add repository's license in the image. 