### PR TITLE
Update helm chart and README.md of labeller

### DIFF
--- a/cmd/k8s-node-labeller/README.md
+++ b/cmd/k8s-node-labeller/README.md
@@ -79,6 +79,10 @@ While container scheduling via label selector works for heterogeneous cluster, i
 
 ## TODOs
 
+## Disclaimer
+
+This optional labeller required privileged container for gpu feature discovery. It is recommended to consult with your cluster administrator or security expert to ensure appropriate security measures are in place.
+
 [ls]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 [ds]: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
 [crd]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/

--- a/cmd/k8s-node-labeller/README.md
+++ b/cmd/k8s-node-labeller/README.md
@@ -15,7 +15,7 @@ This tool automatically label nodes with GPU properties if a node has one or mor
 
 ## Deployment
 
-The Labeller needs to be run on all the nodes that are equipped with AMD GPU.  The simplist way of doing so is to create a Kubernete [DaemonSet][ds], which runs a copy of a pod on all (or some) Nodes in the cluster.  An example configuration is available [here](../../k8s-ds-amdgpu-labeller.yaml).
+The Labeller needs to be run on all the nodes that are equipped with AMD GPU.  The simplist way of doing so is to create a Kubernete [DaemonSet][ds], which runs a copy of a pod on all (or some) Nodes in the cluster.  An example configuration is available [here](../../k8s-ds-amdgpu-labeller.yaml). This labeller required privileged container for gpu feature discovery. It is recommended to consult with your cluster administrator or security expert to ensure appropriate security measures are in place.
 
 The Labeller currently creates node label for the following AMD GPU properties:
 
@@ -78,10 +78,6 @@ While container scheduling via label selector works for heterogeneous cluster, i
 ## Notes
 
 ## TODOs
-
-## Disclaimer
-
-This optional labeller required privileged container for gpu feature discovery. It is recommended to consult with your cluster administrator or security expert to ensure appropriate security measures are in place.
 
 [ls]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 [ds]: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/

--- a/helm/amd-gpu/templates/deviceplugin-daemonset.yaml
+++ b/helm/amd-gpu/templates/deviceplugin-daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ .Chart.Name }}-device-plugin-daemonset
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/helm/amd-gpu/templates/labeller.yaml
+++ b/helm/amd-gpu/templates/labeller.yaml
@@ -43,15 +43,26 @@ spec:
         volumeMounts:
           - name: sys
             mountPath: /sys
-          - name: dev
-            mountPath: /dev
+            readOnly: true
+          - name: dev-kfd
+            mountPath: /dev/kfd
+            readOnly: true
+          - name: dev-dri
+            mountPath: /dev/dri
+            readOnly: true
         resources:
           {{- toYaml .Values.lbl.resources | nindent 10 }}
       volumes:
         - name: sys
           hostPath:
             path: /sys
-        - name: dev
+            type: Directory
+        - name: dev-kfd
           hostPath:
-            path: /dev
+            path: /dev/kfd
+            type: CharDevice
+        - name: dev-dri
+          hostPath:
+            path: /dev/dri
+            type: Directory
 {{- end }}

--- a/helm/amd-gpu/templates/labeller.yaml
+++ b/helm/amd-gpu/templates/labeller.yaml
@@ -1,30 +1,10 @@
+---
 {{- if .Values.labeller.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cr-{{ .Chart.Name }}-node-labeller
-rules:
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["watch", "get", "list", "update"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: crb-{{ .Chart.Name }}-labeller
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cr-{{ .Chart.Name }}-node-labeller
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: {{ .Release.Namespace }}
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ .Chart.Name }}-labeller-daemonset
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
@@ -34,6 +14,7 @@ spec:
       labels:
         name: amdgpu-lr-ds
     spec:
+      serviceAccountName: {{ .Chart.Name }}-node-labeller-sa
       {{- if .Values.node_selector_enabled }}
       {{- with .Values.node_selector }}
       nodeSelector:
@@ -58,9 +39,7 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
         securityContext:
-          privileged: true #Needed for /dev
-          capabilities:
-            drop: ["ALL"]
+          {{- toYaml .Values.lbl.securityContext | nindent 10 }}
         volumeMounts:
           - name: sys
             mountPath: /sys

--- a/helm/amd-gpu/templates/rbac.yaml
+++ b/helm/amd-gpu/templates/rbac.yaml
@@ -1,0 +1,24 @@
+---
+{{- if .Values.labeller.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cr-{{ .Chart.Name }}-node-labeller
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["watch", "get", "list", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-{{ .Chart.Name }}-labeller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-{{ .Chart.Name }}-node-labeller
+subjects:
+- kind: ServiceAccount
+  name: {{ .Chart.Name }}-node-labeller-sa
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/amd-gpu/templates/serviceaccount.yaml
+++ b/helm/amd-gpu/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+{{- if .Values.labeller.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}-node-labeller-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "amd-gpu.labels" . | nindent 4 }}
+  {{- with .Values.lbl.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: true
+{{- end }}

--- a/helm/amd-gpu/values.yaml
+++ b/helm/amd-gpu/values.yaml
@@ -15,7 +15,22 @@ lbl:
   image:
     repository: docker.io/rocm/k8s-device-plugin
     tag: "labeller-1.31.0.2"
+  serviceAccount:
+    annotations: {}
+  securityContext:
+    privileged: true # Needed for /dev
+    capabilities:
+      drop: ["ALL"]  
+    readOnlyRootFilesystem: false # true if -logtostderr flag set in labeller
+  # If you do want to specify resources, uncomment the following lines, 
+  # adjust them as necessary, and remove the curly braces after 'resources:'.
   resources: {}
+    # limits:
+    #   memory: 20Mi
+    #   cpu: 100m
+    # requests:
+    #   memory: 30Mi
+    #   cpu: 150m
 
 imagePullSecrets: []
 

--- a/helm/amd-gpu/values.yaml
+++ b/helm/amd-gpu/values.yaml
@@ -20,7 +20,10 @@ lbl:
   securityContext:
     privileged: true # Needed for /dev
     capabilities:
-      drop: ["ALL"]  
+      drop:
+        - ALL
+      add:
+        - CAP_SYS_ADMIN
     readOnlyRootFilesystem: false # true if -logtostderr flag set in labeller
   # If you do want to specify resources, uncomment the following lines, 
   # adjust them as necessary, and remove the curly braces after 'resources:'.

--- a/k8s-ds-amdgpu-labeller.yaml
+++ b/k8s-ds-amdgpu-labeller.yaml
@@ -21,10 +21,13 @@ roleRef:
   name: cr-node-labeller
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: default
-- kind: ServiceAccount
-  name: default
+  name: node-labeller-sa
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-labeller-sa
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -41,6 +44,7 @@ spec:
       labels:
         name: amdgpu-lr-ds
     spec:
+      serviceAccountName: node-labeller-sa
       nodeSelector:
         kubernetes.io/arch: amd64
       priorityClassName: system-node-critical
@@ -68,6 +72,13 @@ spec:
             mountPath: /sys
           - name: dev
             mountPath: /dev
+        resources: {}
+          # limits:
+          #   memory: 20Mi
+          #   cpu: 100m
+          # requests:
+          #   memory: 30Mi
+          #   cpu: 150m
       volumes:
         - name: sys
           hostPath:

--- a/k8s-ds-amdgpu-labeller.yaml
+++ b/k8s-ds-amdgpu-labeller.yaml
@@ -70,8 +70,13 @@ spec:
         volumeMounts:
           - name: sys
             mountPath: /sys
-          - name: dev
-            mountPath: /dev
+            readOnly: true
+          - name: dev-kfd
+            mountPath: /dev/kfd
+            readOnly: true
+          - name: dev-dri
+            mountPath: /dev/dri
+            readOnly: true
         resources: {}
           # limits:
           #   memory: 20Mi
@@ -83,6 +88,12 @@ spec:
         - name: sys
           hostPath:
             path: /sys
-        - name: dev
+            type: Directory
+        - name: dev-kfd
           hostPath:
-            path: /dev
+            path: /dev/kfd
+            type: CharDevice
+        - name: dev-dri
+          hostPath:
+            path: /dev/dri
+            type: Directory


### PR DESCRIPTION
To ensure permission isolation, role binding to default service account is removed and associated to a new service account. The namespace of both labeller and device-plugin DaemonSet are configured to align release namespace of helm. The example manifest is also updated to reflect the changes.

The README.md is updated for security awareness on privileged container.