### PR TITLE
node labeller "-product-name" failing for some platforms on k8s

### DIFF
--- a/cmd/k8s-node-labeller/main.go
+++ b/cmd/k8s-node-labeller/main.go
@@ -164,7 +164,7 @@ var labelGenerators = map[string]func(map[string]map[string]int) map[string]stri
 	},
 	"product-name": func(gpus map[string]map[string]int) map[string]string {
 		counts := map[string]int{}
-		replacer := strings.NewReplacer(" ", "_")
+		replacer := strings.NewReplacer(" ", "_", "(", "", ")", "")
 
 		for _, v := range gpus {
 			prodnamePath := fmt.Sprintf("/sys/class/drm/card%d/device/product_name", v["card"])


### PR DESCRIPTION
Removing brackets from product name to conforming label with k8s requirement

```
amd@bespin:~$ /opt/rocm/bin/amd-smi static | grep INSTI
        MARKET_NAME: AMD INSTINCT MI250X (MCM) OAM AC MBA MSFT
        PRODUCT_NAME: AMD INSTINCT MI250X (MCM) OAM AC MBA MSFT
```


Issue 
```
{"level":"error","ts":"2025-02-07T19:57:03Z","msg":"Reconciler error","controller":"amdgpu-node-labeller","object":{"name":"bespin"},"namespace":"","name":"bespin","reconcileID":"edbbf722-5894-4c65-9795-ad4cbd1d203b","error":"Node \"bespin\" is invalid: [metadata.labels: Invalid value: \"AMD_INSTINCT_MI250X_(MCM)OAM_AC_MBA_MSFT\": a valid label must be an empty string or consist of alphanumeric characters, '-', '' or '.', 
and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.])?[A-Za-z0-9])?'), metadata.labels: Invalid value: \"[beta.amd.com/gpu.product-name.AMD_INSTINCT_MI250X_(MCM)](http://beta.amd.com/gpu.product-name.AMD_INSTINCT_MI250X_(MCM))OAM_AC_MBA_MSFT\": name part must consist of alphanumeric characters, '-', '' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  
or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.])?[A-Za-z0-9]')]","stacktrace":"[sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]](http://sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller%5B...%5D)).reconcileHandler\n\t/go/src/github.com/ROCm/k8s-device-plugin/vendor/sigs.k8s.io/controller-
runtime/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/src/github.com/ROCm/k8s
```