### PR TITLE
Update rhubi-based image labels for OpenShift certification

### DIFF
--- a/ubi-dp.Dockerfile
+++ b/ubi-dp.Dockerfile
@@ -33,10 +33,13 @@ RUN go install \
 
 FROM registry.access.redhat.com/ubi9/ubi-init:9.4
 LABEL \
-    org.opencontainers.image.source="https://github.com/ROCm/k8s-device-plugin" \
-    org.opencontainers.image.authors="Yan Sun <Yan.Sun3@amd.com>" \
-    org.opencontainers.image.vendor="Advanced Micro Devices, Inc." \
-    org.opencontainers.image.licenses="Apache-2.0"
+    name="amd-k8s-device-plugin" \ 
+    maintainer="shrey.ajmera@amd.com,yan.sun3@amd.com,praveenkumar.shanmugam@amd.com,nitish.bhat@amd.com,sriram.ravishankar@amd.com,udaybhaskar.biluri@amd.com" \
+    vendor="Advanced Micro Devices, Inc." \
+    version="latest" \
+    release="latest" \
+    summary="The AMD K8s Device Plugin enables the registration of AMD GPUs in your Kubernetes cluster for compute workloads." \
+    description="The AMD K8s Device Plugin enables the registration of AMD GPUs in your Kubernetes cluster for compute workloads. With the appropriate hardware and this plugin deployed in your Kubernetes cluster, you will be able to run jobs that require AMD GPU."
 RUN mkdir -p /licenses && \
     dnf install -y ca-certificates libdrm && \
     rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official && \

--- a/ubi-labeller.Dockerfile
+++ b/ubi-labeller.Dockerfile
@@ -32,11 +32,13 @@ RUN go install \
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 LABEL \
-    org.opencontainers.image.source="https://github.com/ROCm/k8s-device-plugin" \
-    org.opencontainers.image.authors="Yan Sun <Yan.Sun3@amd.com>" \
-    org.opencontainers.image.vendor="Advanced Micro Devices, Inc." \
-    org.opencontainers.image.licenses="Apache-2.0"
-
+    name="amd-k8s-node-labeller" \ 
+    maintainer="shrey.ajmera@amd.com,yan.sun3@amd.com,praveenkumar.shanmugam@amd.com,nitish.bhat@amd.com,sriram.ravishankar@amd.com,udaybhaskar.biluri@amd.com" \
+    vendor="Advanced Micro Devices, Inc." \
+    version="latest" \
+    release="latest" \
+    summary="The AMD Node Labeller automatically detects and labels Kubernetes nodes with AMD GPU hardware." \
+    description="The AMD Node Labeller automatically detects and labels Kubernetes nodes with AMD GPU hardware. This tool automatically labels nodes with GPU properties if a node has one or more AMD GPU installed."
 RUN mkdir -p /licenses && \
     microdnf install -y ca-certificates libdrm && \
     microdnf clean all


### PR DESCRIPTION
RedHat OpenShift certification process raised a [new standard of image metadata](https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html/red_hat_openshift_software_certification_policy_guide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction#con-image-metadata-requirements_openshift-sw-cert-policy-container-images).

This PR is updating the RedHat UBI based device plugin and node labeller image labels to meet the new requirement for passing the new certification process.