### PR TITLE
Support updateStrategy for helm chart daemonsets

### DIFF
--- a/helm/amd-gpu/templates/deviceplugin-daemonset.yaml
+++ b/helm/amd-gpu/templates/deviceplugin-daemonset.yaml
@@ -7,6 +7,10 @@ spec:
   selector:
     matchLabels:
       name: {{ .Chart.Name }}-dp-ds
+  {{- with .Values.dp.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/helm/amd-gpu/templates/labeller.yaml
+++ b/helm/amd-gpu/templates/labeller.yaml
@@ -9,6 +9,10 @@ spec:
   selector:
     matchLabels:
       name: amdgpu-lr-ds
+  {{- with .Values.lbl.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/helm/amd-gpu/values.yaml
+++ b/helm/amd-gpu/values.yaml
@@ -10,6 +10,11 @@ dp:
     # Overrides the image tag whose default is the chart appVersion.
     tag: "1.31.0.6"
   resources: {}
+  # Set daemonsets updateStrategy for device plugin
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
 
 lbl:
   image:
@@ -34,6 +39,11 @@ lbl:
     # requests:
     #   memory: 30Mi
     #   cpu: 150m
+  # Set daemonsets updateStrategy for labeller
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
 
 imagePullSecrets: []
 


### PR DESCRIPTION
The PR adds support for setting updateStrategy for daemonsets of device-plugin & labeller.