### PR TITLE
Fix k8s-node-labeller cleanup on node labels

### DIFF
--- a/cmd/k8s-node-labeller/controller.go
+++ b/cmd/k8s-node-labeller/controller.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"strings"
 
 	"github.com/go-logr/logr"
 
@@ -43,12 +42,7 @@ func (r *reconcileNodeLabels) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	// Remove old labels
-	for k := range node.Labels {
-		if strings.HasPrefix(k, "beta.amd.com") ||
-			strings.HasPrefix(k, "amd.com") {
-			delete(node.Labels, k)
-		}
-	}
+	removeOldNodeLabels(node)
 
 	for k, v := range r.labels {
 		node.Labels[k] = v

--- a/cmd/k8s-node-labeller/main_test.go
+++ b/cmd/k8s-node-labeller/main_test.go
@@ -1,7 +1,119 @@
 package main
 
-import "testing"
+import (
+	"reflect"
+	"testing"
 
-func TestHelloWorld(t *testing.T) {
-	// t.Fatal("not implemented")
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	expectedAllLabelKeys = map[string]bool{
+		"amd.com/gpu.family":             true,
+		"amd.com/gpu.driver-version":     true,
+		"amd.com/gpu.driver-src-version": true,
+		"amd.com/gpu.firmware":           true,
+		"amd.com/gpu.device-id":          true,
+		"amd.com/gpu.product-name":       true,
+		"amd.com/gpu.vram":               true,
+		"amd.com/gpu.simd-count":         true,
+		"amd.com/gpu.cu-count":           true,
+	}
+	expectedAllExperimentalLabelKeys = map[string]bool{
+		"beta.amd.com/gpu.family":             true,
+		"beta.amd.com/gpu.driver-version":     true,
+		"beta.amd.com/gpu.driver-src-version": true,
+		"beta.amd.com/gpu.firmware":           true,
+		"beta.amd.com/gpu.device-id":          true,
+		"beta.amd.com/gpu.product-name":       true,
+		"beta.amd.com/gpu.vram":               true,
+		"beta.amd.com/gpu.simd-count":         true,
+		"beta.amd.com/gpu.cu-count":           true,
+	}
+)
+
+func TestInitLabelLists(t *testing.T) {
+	labelMap := map[string]bool{}
+	for _, label := range allLabelKeys {
+		labelMap[label] = true
+	}
+	if !reflect.DeepEqual(labelMap, expectedAllLabelKeys) {
+		t.Errorf("failed to get expected all labels during init, got %+v, expect %+v", labelMap, expectedAllLabelKeys)
+	}
+	experimentalLabelMap := map[string]bool{}
+	for _, label := range allExperimentalLabelKeys {
+		experimentalLabelMap[label] = true
+	}
+	if !reflect.DeepEqual(experimentalLabelMap, expectedAllExperimentalLabelKeys) {
+		t.Errorf("failed to get expected all experimental labels during init, got %+v, expect %+v", labelMap, expectedAllLabelKeys)
+	}
+}
+
+func TestRemoveOldNodeLabels(t *testing.T) {
+	testCases := []struct {
+		inputNode    *corev1.Node
+		expectLabels map[string]string
+	}{
+		{
+			inputNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"amd.com/gpu.cu-count":                          "104",
+						"amd.com/gpu.device-id":                         "740f",
+						"amd.com/gpu.driver-version":                    "6.10.5",
+						"amd.com/gpu.family":                            "AI",
+						"amd.com/gpu.product-name":                      "Instinct_MI210",
+						"amd.com/gpu.simd-count":                        "416",
+						"amd.com/gpu.vram":                              "64G",
+						"beta.amd.com/gpu.cu-count":                     "104",
+						"beta.amd.com/gpu.cu-count.104":                 "1",
+						"beta.amd.com/gpu.device-id":                    "740f",
+						"beta.amd.com/gpu.device-id.740f":               "1",
+						"beta.amd.com/gpu.family":                       "HPC",
+						"beta.amd.com/gpu.family.HPC":                   "1",
+						"beta.amd.com/gpu.product-name":                 "Instinct_MI300X",
+						"beta.amd.com/gpu.product-name.Instinct_MI300X": "1",
+						"beta.amd.com/gpu.simd-count":                   "416",
+						"beta.amd.com/gpu.simd-count.416":               "1",
+						"beta.amd.com/gpu.vram":                         "64G",
+						"beta.amd.com/gpu.vram.64G":                     "1",
+						"dummyLabel1":                                   "1",
+						"dummyLabel2":                                   "2",
+					},
+				},
+			},
+			expectLabels: map[string]string{
+				"dummyLabel1": "1",
+				"dummyLabel2": "2",
+			},
+		},
+		{
+			inputNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"amd.com/cpu":    "true",
+						"amd.com/gpu":    "true",
+						"amd.com/mi300x": "true",
+						"dummyLabel1":    "1",
+						"dummyLabel2":    "2",
+					},
+				},
+			},
+			expectLabels: map[string]string{
+				"amd.com/cpu":    "true",
+				"amd.com/gpu":    "true",
+				"amd.com/mi300x": "true",
+				"dummyLabel1":    "1",
+				"dummyLabel2":    "2",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		removeOldNodeLabels(tc.inputNode)
+		if !reflect.DeepEqual(tc.inputNode.Labels, tc.expectLabels) {
+			t.Errorf("failed to get expected node labels after removing old labels, got %+v, expect %+v", tc.inputNode.Labels, tc.expectLabels)
+		}
+	}
 }


### PR DESCRIPTION
# Fix
The k8s-node-labeller currently removes all labels with the amd.com or beta.amd.com prefix on nodes during cleanup. This is overly aggressive and can delete labels added/required by other systems/users/components.
This PR corrects the behavior to only remove node labels that are specifically managed by k8s-node-labeller itself, ensuring that only relevant labels are automatically cleaned up.

# Enhancement
1. Test Coverage: Added unit test cases to make sure this fix is removing the target node labels
2. Time complexity improvement: The existing node label cleanup logic is iterating over all node labels on all nodes and doing string comparison to determine which labels are to be removed. With the fix in this PR, we don't have to iterate each node label in the list, just delete the node labels that k8s-node-labeller is managing. From the time complexity points of view, the fix optimized the time spent on each Node.

# Reproduce
1. Bring up a Kuberntes cluster with AMD GPU
3. Users mark the worker node with labels that have ```amd.com``` prefix, e.g. ```amd.com/cpu```, ```amd.com/gpu```.
4. Create k8s-node-labeller daemonset by using [example](https://github.com/ROCm/k8s-device-plugin/blob/master/k8s-ds-amdgpu-labeller.yaml) YAML file.
5. Found that the ```amd.com``` labels users added have been removed.