### PR TITLE
add fallback mechanism in case allocator init fails

### DIFF
--- a/internal/pkg/allocator/besteffort_policy.go
+++ b/internal/pkg/allocator/besteffort_policy.go
@@ -69,6 +69,9 @@ func (b *BestEffortPolicy) getDevicesFromIds(ids []string) []*Device {
 // Init initializes pair wise weights of all devices and stores in-memory
 func (b *BestEffortPolicy) Init(devs []*Device, topoDir string) error {
 	err := fetchAllPairWeights(devs, b.p2pWeights, topoDir)
+	if len(b.p2pWeights) == 0 {
+		return fmt.Errorf("Besteffort Policy init failed to initialize p2pWeights")
+	}
 	if err == nil {
 		b.devices = devs
 		for idx := range devs {


### PR DESCRIPTION
we currently use besteffort allocation policy for default allocation strategy. for some reason if the allocator initialization fails, we need to fall back to kubelet/k8s default behaviour