### PR TITLE
modify gpu allocator logic to avoid fragmentation of unused GPUs

### DIFF
--- a/docs/user-guide/resource-allocation.md
+++ b/docs/user-guide/resource-allocation.md
@@ -16,3 +16,8 @@ Currently we use ```best-effort``` policy as the default allocation policy. This
 - For scenarios that involve partitioned GPUs, partitions from same GPU are assigned better score than partitions from different GPUs.
 
 When an allocation request for size S comes, the allocator calculates all subsets of size S out of available GPUs. For each set, the score is maintained(based on above criteria). Set with lowest score is picked for allocation. At any given time, best-effort policy tries to provide best possible combination of GPUs out of the avilable GPU pool.
+
+Below are few rules followed for allocation requests for X GPU partitions:
+- We try to allocate all partitions from the same GPU if possible.
+- In case there is a GPU with fewer available partitions that can accomodate the request, that GPU is preferred. This maximizes the utilization of GPUs already in use for other workloads and helps avoid fragmentation of unused GPUs.
+- If more than one GPU is needed to accomodate the request, we consider the topology(link type and NUMA affinity) as described above and generate all possible subsets. The subset with the lowest weight among the possible candidates is allocated.

--- a/internal/pkg/allocator/besteffort_policy_test.go
+++ b/internal/pkg/allocator/besteffort_policy_test.go
@@ -100,19 +100,19 @@ func TestBestPolicyAllocator(t *testing.T) {
 				description: "Allocate 1 device",
 				size:        1,
 				required:    nil,
-				expectedIds: []string{"test1"},
+				expectedIds: []string{"test8"},
 			},
 			{
 				description: "Allocate 3 devices",
 				size:        3,
 				required:    nil,
-				expectedIds: []string{"test1", "amdgpu_xcp_1", "amdgpu_xcp_2"},
+				expectedIds: []string{"test8", "amdgpu_xcp_57", "amdgpu_xcp_58"},
 			},
 			{
 				description: "Allocate 5 devices",
 				size:        5,
 				required:    nil,
-				expectedIds: []string{"test1", "amdgpu_xcp_1", "amdgpu_xcp_2", "amdgpu_xcp_3", "amdgpu_xcp_4"},
+				expectedIds: []string{"test8", "amdgpu_xcp_57", "amdgpu_xcp_58", "amdgpu_xcp_59", "amdgpu_xcp_60"},
 			},
 			{
 				description: "Allocate 3 - same numa",
@@ -137,6 +137,26 @@ func TestBestPolicyAllocator(t *testing.T) {
 				size:        8,
 				expectedIds: []string{"test1", "amdgpu_xcp_1", "amdgpu_xcp_2", "amdgpu_xcp_3", "amdgpu_xcp_4", "amdgpu_xcp_5", "amdgpu_xcp_6", "amdgpu_xcp_7"},
 			},
+			{
+				description: "Allocate 7 devices",
+				size:        7,
+				required:    nil,
+				expectedIds: []string{"test8", "amdgpu_xcp_57", "amdgpu_xcp_58", "amdgpu_xcp_59", "amdgpu_xcp_60", "amdgpu_xcp_61", "amdgpu_xcp_62"},
+			},
+			{
+				description: "Allocate 4 devices",
+				size:        4,
+				required:    nil,
+				filtered:    []string{"test8", "amdgpu_xcp_57", "amdgpu_xcp_58"},
+				expectedIds: []string{"amdgpu_xcp_59", "amdgpu_xcp_60", "amdgpu_xcp_61", "amdgpu_xcp_62"},
+			},
+			{
+				description: "Allocate 10 devices",
+				size:        10,
+				required:    nil,
+				filtered:    []string{"test1", "test2", "test3", "test4", "test8", "amdgpu_xcp_57"},
+				expectedIds: []string{"test5", "amdgpu_xcp_33", "amdgpu_xcp_34", "amdgpu_xcp_35", "amdgpu_xcp_36", "amdgpu_xcp_37", "amdgpu_xcp_38", "amdgpu_xcp_39", "amdgpu_xcp_58", "amdgpu_xcp_59"},
+			},
 		},
 	}
 
@@ -156,6 +176,9 @@ func TestBestPolicyAllocator(t *testing.T) {
 				av = tc.available
 			} else {
 				av = allAvailableIds
+			}
+			if len(tc.filtered) > 0 {
+				av = topo.getFilteredDeviceIds(av, tc.filtered)
 			}
 			if len(tc.required) > 0 {
 				req = tc.required

--- a/internal/pkg/allocator/device_test.go
+++ b/internal/pkg/allocator/device_test.go
@@ -18,6 +18,7 @@ package allocator
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"testing"
 )
@@ -30,6 +31,7 @@ type testInfo struct {
 	startNodeId           int
 	endNodeId             int
 	available             []string
+	filtered              []string
 	required              []string
 	size                  int
 	expectedIds           []string
@@ -59,6 +61,17 @@ func (ti *testInfo) getTestDevices() []*Device {
 				DevId:    strconv.Itoa(i),
 			})
 			nodeId = nodeId + 1
+		}
+	}
+	return res
+}
+
+func (ti *testInfo) getFilteredDeviceIds(available, filter []string) []string {
+	var res []string
+	for _, av := range available {
+		idx := slices.Index(filter, av)
+		if idx == -1 {
+			res = append(res, av)
 		}
 	}
 	return res
@@ -135,7 +148,7 @@ func TestGetSubsetsMethod(t *testing.T) {
 		{
 			description:           "Get candidates with size 12",
 			size:                  12,
-			expectedSubsetsLength: 6,
+			expectedSubsetsLength: 12,
 		},
 	}
 	for _, tcase := range testcases {


### PR DESCRIPTION
Below are few rules followed for allocation requests for X GPU partitions:
- We try to allocate all partitions from the same GPU if possible.
- In case there is a GPU with fewer available partitions that can accomodate the request, that GPU is preferred. This maximizes the utilization of GPUs already in use for other workloads and helps avoid fragmentation of unused GPUs.
- If more than one GPU is needed to accommodate the request, we consider the topology(link type and NUMA affinity) as described above and generate all possible subsets. The subset with the lowest weight among the possible candidates is allocated.