### PR TITLE
fix: prevent cross-device identity reuse during AMD GPU discovery

### DIFF
--- a/internal/pkg/amdgpu/amdgpu.go
+++ b/internal/pkg/amdgpu/amdgpu.go
@@ -147,6 +147,147 @@ func GetDevIdsFromTopology(topoRootParam ...string) map[int]string {
 	return renderDevIds
 }
 
+type deviceIdentity struct {
+	card    int
+	renderD int
+	devID   string
+	nodeID  int
+}
+
+var (
+	drmCardNameRe   = regexp.MustCompile(`^card([0-9]+)$`)
+	drmRenderNameRe = regexp.MustCompile(`^renderD([0-9]+)$`)
+)
+
+// resolveDeviceIdentity resolves the DRM and KFD identity of a single discovery
+// candidate from its own drm entries. Every call starts from invalid sentinels,
+// so no field can be inherited from a previously enumerated device, and an
+// incomplete, malformed, conflicting or unmapped identity is an error.
+func resolveDeviceIdentity(
+	devPaths []string,
+	renderDevIds map[int]string,
+	renderNodeIds map[int]int,
+) (deviceIdentity, error) {
+	identity := deviceIdentity{
+		card:    -1,
+		renderD: -1,
+		nodeID:  -1,
+	}
+
+	for _, devPath := range devPaths {
+		name := filepath.Base(devPath)
+
+		if match := drmCardNameRe.FindStringSubmatch(name); match != nil {
+			card, err := strconv.Atoi(match[1])
+			if err != nil {
+				return deviceIdentity{}, fmt.Errorf(
+					"parse DRM card entry %q: %w",
+					name,
+					err,
+				)
+			}
+			if identity.card >= 0 && identity.card != card {
+				return deviceIdentity{}, fmt.Errorf(
+					"conflicting DRM card entries: card%d and card%d",
+					identity.card,
+					card,
+				)
+			}
+			identity.card = card
+			continue
+		}
+
+		if match := drmRenderNameRe.FindStringSubmatch(name); match != nil {
+			renderD, err := strconv.Atoi(match[1])
+			if err != nil {
+				return deviceIdentity{}, fmt.Errorf(
+					"parse DRM render entry %q: %w",
+					name,
+					err,
+				)
+			}
+			if identity.renderD >= 0 && identity.renderD != renderD {
+				return deviceIdentity{}, fmt.Errorf(
+					"conflicting DRM render entries: renderD%d and renderD%d",
+					identity.renderD,
+					renderD,
+				)
+			}
+			identity.renderD = renderD
+		}
+	}
+
+	if identity.card < 0 || identity.renderD < 0 {
+		return deviceIdentity{}, fmt.Errorf(
+			"incomplete DRM identity: card=%d renderD=%d",
+			identity.card,
+			identity.renderD,
+		)
+	}
+
+	devID, exists := renderDevIds[identity.renderD]
+	if !exists || devID == "" {
+		return deviceIdentity{}, fmt.Errorf(
+			"renderD%d has no KFD device identity",
+			identity.renderD,
+		)
+	}
+
+	nodeID, exists := renderNodeIds[identity.renderD]
+	if !exists {
+		return deviceIdentity{}, fmt.Errorf(
+			"renderD%d has no KFD node ID",
+			identity.renderD,
+		)
+	}
+
+	identity.devID = devID
+	identity.nodeID = nodeID
+	return identity, nil
+}
+
+// recordParentGPU records a physical GPU as the parent candidate for its KFD
+// device identity. That identity is built from the bus and device numbers only,
+// so two functions of one PCI device share it and neither can name a single
+// parent. Such an identity is removed and kept out, and false is returned.
+func recordParentGPU(
+	parents map[string]map[string]interface{},
+	ambiguous map[string]struct{},
+	devID string,
+	device map[string]interface{},
+) bool {
+	if _, seen := ambiguous[devID]; seen {
+		return false
+	}
+	if _, exists := parents[devID]; exists {
+		delete(parents, devID)
+		ambiguous[devID] = struct{}{}
+		return false
+	}
+
+	parents[devID] = device
+	return true
+}
+
+// partitionMetadataFromParent returns the fields an XCP partition inherits from
+// its physical GPU, or an error naming which of them is unusable.
+func partitionMetadataFromParent(parent map[string]interface{}) (string, string, int, error) {
+	computePartitionType, computeOK := parent["computePartitionType"].(string)
+	memoryPartitionType, memoryOK := parent["memoryPartitionType"].(string)
+	numaNode, numaOK := parent["numaNode"].(int)
+
+	if !computeOK || !memoryOK || !numaOK {
+		return "", "", -1, errors.New("malformed partition metadata")
+	}
+	if computePartitionType == "" || memoryPartitionType == "" {
+		return "", "", -1, errors.New("no partition type")
+	}
+	if numaNode < 0 {
+		return "", "", -1, errors.New("no NUMA node")
+	}
+	return computePartitionType, memoryPartitionType, numaNode, nil
+}
+
 // FatalOnDriverUnavailable controls whether GetAMDGPUs calls glog.Fatalf
 // when the amdgpu driver is not present. Tests set this to false so the
 // test process isn't killed on machines without AMD GPUs.
@@ -165,9 +306,9 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 	//ex: /sys/module/amdgpu/drivers/pci:amdgpu/0000:19:00.0
 	matches, _ := filepath.Glob("/sys/module/amdgpu/drivers/pci:amdgpu/[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]:*")
 
-	devID := ""
 	devices := make(map[string]map[string]interface{})
-	card, renderD, nodeId := 0, 128, 0
+	physicalDevicesByDevID := make(map[string]map[string]interface{})
+	ambiguousDevIDs := make(map[string]struct{})
 	renderDevIds := GetDevIdsFromTopology()
 	renderNodeIds := GetNodeIdsFromTopology()
 
@@ -208,23 +349,41 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		glog.Info(path)
 		devPaths, _ := filepath.Glob(path + "/drm/*")
 
-		for _, devPath := range devPaths {
-			switch name := filepath.Base(devPath); {
-			case name[0:4] == "card":
-				card, _ = strconv.Atoi(name[4:])
-			case name[0:7] == "renderD":
-				renderD, _ = strconv.Atoi(name[7:])
-				if val, exists := renderDevIds[renderD]; exists {
-					devID = val
-				}
-				if id, exists := renderNodeIds[renderD]; exists {
-					nodeId = id
-				}
-			}
-
+		identity, err := resolveDeviceIdentity(
+			devPaths,
+			renderDevIds,
+			renderNodeIds,
+		)
+		if err != nil {
+			glog.Warningf(
+				"Skipping AMD GPU %s: %v",
+				filepath.Base(path),
+				err,
+			)
+			continue
 		}
+
 		// add devID so that we can identify later which gpu should get reported under which resource type
-		devices[filepath.Base(path)] = map[string]interface{}{"card": card, "renderD": renderD, "devID": devID, "computePartitionType": computePartitionType, "memoryPartitionType": memoryPartitionType, "numaNode": numaNode, "nodeId": nodeId}
+		device := map[string]interface{}{
+			"card":                 identity.card,
+			"renderD":              identity.renderD,
+			"devID":                identity.devID,
+			"computePartitionType": computePartitionType,
+			"memoryPartitionType":  memoryPartitionType,
+			"numaNode":             numaNode,
+			"nodeId":               identity.nodeID,
+		}
+
+		devices[filepath.Base(path)] = device
+
+		// Both GPUs are still reported even when they share an identity, only
+		// the parent inventory has to stay unambiguous for the partitions.
+		if !recordParentGPU(physicalDevicesByDevID, ambiguousDevIDs, identity.devID, device) {
+			glog.Warningf(
+				"KFD device identity %s is claimed by more than one physical GPU, its partitions will not be reported",
+				identity.devID,
+			)
+		}
 	}
 
 	// certain products have additional devices (such as MI300's partitions)
@@ -235,44 +394,53 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		glog.Info(path)
 		devPaths, _ := filepath.Glob(path + "/drm/*")
 
-		computePartitionType, memoryPartitionType := "", ""
-		numaNode := -1
-
-		for _, devPath := range devPaths {
-			switch name := filepath.Base(devPath); {
-			case name[0:4] == "card":
-				card, _ = strconv.Atoi(name[4:])
-			case name[0:7] == "renderD":
-				renderD, _ = strconv.Atoi(name[7:])
-				if val, exists := renderDevIds[renderD]; exists {
-					devID = val
-				}
-				// Set the computePartitionType and memoryPartitionType from the real GPU or from other partitions using the common devID
-				for _, device := range devices {
-					if device["devID"] == devID {
-						if device["computePartitionType"].(string) != "" && device["memoryPartitionType"].(string) != "" {
-							computePartitionType = device["computePartitionType"].(string)
-							memoryPartitionType = device["memoryPartitionType"].(string)
-							numaNode = device["numaNode"].(int)
-							break
-						}
-					}
-				}
-				if id, exists := renderNodeIds[renderD]; exists {
-					nodeId = id
-				}
-			}
+		identity, err := resolveDeviceIdentity(
+			devPaths,
+			renderDevIds,
+			renderNodeIds,
+		)
+		if err != nil {
+			glog.Warningf(
+				"Skipping AMD GPU partition %s: %v",
+				filepath.Base(path),
+				err,
+			)
+			continue
 		}
+
 		// This is needed because some of the visible renderD are actually not valid
 		// Their validity depends on topology information from KFD
+		parent, exists := physicalDevicesByDevID[identity.devID]
+		if !exists {
+			glog.Warningf(
+				"Skipping AMD GPU partition %s: no physical GPU found for KFD device identity %s",
+				filepath.Base(path),
+				identity.devID,
+			)
+			continue
+		}
 
-		if _, exists := renderDevIds[renderD]; !exists {
+		// Set the computePartitionType, memoryPartitionType and numaNode from the physical GPU
+		computePartitionType, memoryPartitionType, numaNode, err := partitionMetadataFromParent(parent)
+		if err != nil {
+			glog.Warningf(
+				"Skipping AMD GPU partition %s: physical GPU %s has %v",
+				filepath.Base(path),
+				identity.devID,
+				err,
+			)
 			continue
 		}
-		if numaNode == -1 {
-			continue
+
+		devices[filepath.Base(path)] = map[string]interface{}{
+			"card":                 identity.card,
+			"renderD":              identity.renderD,
+			"devID":                identity.devID,
+			"computePartitionType": computePartitionType,
+			"memoryPartitionType":  memoryPartitionType,
+			"numaNode":             numaNode,
+			"nodeId":               identity.nodeID,
 		}
-		devices[filepath.Base(path)] = map[string]interface{}{"card": card, "renderD": renderD, "devID": devID, "computePartitionType": computePartitionType, "memoryPartitionType": memoryPartitionType, "numaNode": numaNode, "nodeId": nodeId}
 	}
 	glog.Infof("Devices map: %v", devices)
 	return devices

--- a/internal/pkg/amdgpu/amdgpu_test.go
+++ b/internal/pkg/amdgpu/amdgpu_test.go
@@ -268,3 +268,369 @@ func TestRenderDevIdsFromTopology(t *testing.T) {
 		t.Errorf("Want: %s", exp)
 	}
 }
+
+func TestResolveDeviceIdentity(t *testing.T) {
+	tests := []struct {
+		name            string
+		devPaths        []string
+		renderDevIDs    map[int]string
+		renderNodeIDs   map[int]int
+		want            deviceIdentity
+		wantErrContains string
+	}{
+		{
+			name:          "complete identity",
+			devPaths:      []string{"/sys/devices/card0", "/sys/devices/renderD128"},
+			renderDevIDs:  map[int]string{128: "0000:01:00:0"},
+			renderNodeIDs: map[int]int{128: 1},
+			want: deviceIdentity{
+				card:    0,
+				renderD: 128,
+				devID:   "0000:01:00:0",
+				nodeID:  1,
+			},
+		},
+		{
+			name:          "KFD node zero is valid",
+			devPaths:      []string{"/sys/devices/card0", "/sys/devices/renderD128"},
+			renderDevIDs:  map[int]string{128: "0000:01:00:0"},
+			renderNodeIDs: map[int]int{128: 0},
+			want: deviceIdentity{
+				card:    0,
+				renderD: 128,
+				devID:   "0000:01:00:0",
+				nodeID:  0,
+			},
+		},
+		{
+			name:            "missing card",
+			devPaths:        []string{"/sys/devices/renderD128"},
+			renderDevIDs:    map[int]string{128: "0000:01:00:0"},
+			renderNodeIDs:   map[int]int{128: 1},
+			wantErrContains: "incomplete DRM identity",
+		},
+		{
+			name:            "missing render node",
+			devPaths:        []string{"/sys/devices/card0"},
+			renderDevIDs:    map[int]string{128: "0000:01:00:0"},
+			renderNodeIDs:   map[int]int{128: 1},
+			wantErrContains: "incomplete DRM identity",
+		},
+		{
+			name:            "missing KFD device identity",
+			devPaths:        []string{"/sys/devices/card1", "/sys/devices/renderD129"},
+			renderDevIDs:    map[int]string{},
+			renderNodeIDs:   map[int]int{129: 2},
+			wantErrContains: "no KFD device identity",
+		},
+		{
+			name:            "empty KFD device identity",
+			devPaths:        []string{"/sys/devices/card1", "/sys/devices/renderD129"},
+			renderDevIDs:    map[int]string{129: ""},
+			renderNodeIDs:   map[int]int{129: 2},
+			wantErrContains: "no KFD device identity",
+		},
+		{
+			name:            "missing KFD node ID",
+			devPaths:        []string{"/sys/devices/card1", "/sys/devices/renderD129"},
+			renderDevIDs:    map[int]string{129: "0000:02:00:0"},
+			renderNodeIDs:   map[int]int{},
+			wantErrContains: "no KFD node ID",
+		},
+		{
+			name: "short and unrelated entries do not panic",
+			devPaths: []string{
+				"/sys/devices/c",
+				"/sys/devices/controlD64",
+				"/sys/devices/renderD128",
+			},
+			renderDevIDs:    map[int]string{128: "0000:01:00:0"},
+			renderNodeIDs:   map[int]int{128: 1},
+			wantErrContains: "incomplete DRM identity",
+		},
+		{
+			name:            "card index that does not fit an int",
+			devPaths:        []string{"/sys/devices/card99999999999999999999", "/sys/devices/renderD128"},
+			renderDevIDs:    map[int]string{128: "0000:01:00:0"},
+			renderNodeIDs:   map[int]int{128: 1},
+			wantErrContains: "parse DRM card entry",
+		},
+		{
+			name:            "render index that does not fit an int",
+			devPaths:        []string{"/sys/devices/card0", "/sys/devices/renderD99999999999999999999"},
+			renderDevIDs:    map[int]string{128: "0000:01:00:0"},
+			renderNodeIDs:   map[int]int{128: 1},
+			wantErrContains: "parse DRM render entry",
+		},
+		{
+			name: "connector entry is not a card entry",
+			devPaths: []string{
+				"/sys/devices/card0-DP-1",
+				"/sys/devices/renderD128",
+			},
+			renderDevIDs:    map[int]string{128: "0000:01:00:0"},
+			renderNodeIDs:   map[int]int{128: 1},
+			wantErrContains: "incomplete DRM identity",
+		},
+		{
+			name: "render entry with a trailing suffix is not a render entry",
+			devPaths: []string{
+				"/sys/devices/card0",
+				"/sys/devices/renderD128x",
+			},
+			renderDevIDs:    map[int]string{128: "0000:01:00:0"},
+			renderNodeIDs:   map[int]int{128: 1},
+			wantErrContains: "incomplete DRM identity",
+		},
+		{
+			name: "conflicting cards",
+			devPaths: []string{
+				"/sys/devices/card0",
+				"/sys/devices/card1",
+				"/sys/devices/renderD128",
+			},
+			renderDevIDs:    map[int]string{128: "0000:01:00:0"},
+			renderNodeIDs:   map[int]int{128: 1},
+			wantErrContains: "conflicting DRM card entries",
+		},
+		{
+			name: "conflicting render nodes",
+			devPaths: []string{
+				"/sys/devices/card0",
+				"/sys/devices/renderD128",
+				"/sys/devices/renderD129",
+			},
+			renderDevIDs: map[int]string{
+				128: "0000:01:00:0",
+				129: "0000:02:00:0",
+			},
+			renderNodeIDs: map[int]int{
+				128: 1,
+				129: 2,
+			},
+			wantErrContains: "conflicting DRM render entries",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveDeviceIdentity(
+				tt.devPaths,
+				tt.renderDevIDs,
+				tt.renderNodeIDs,
+			)
+
+			if tt.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf(
+						"resolveDeviceIdentity() error = nil, want %q",
+						tt.wantErrContains,
+					)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf(
+						"resolveDeviceIdentity() error = %q, want substring %q",
+						err,
+						tt.wantErrContains,
+					)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("resolveDeviceIdentity() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf(
+					"resolveDeviceIdentity() = %#v, want %#v",
+					got,
+					tt.want,
+				)
+			}
+		})
+	}
+}
+
+func TestResolveDeviceIdentityDoesNotReusePreviousDevice(t *testing.T) {
+	renderDevIDs := map[int]string{
+		128: "0000:01:00:0",
+	}
+	renderNodeIDs := map[int]int{
+		128: 1,
+	}
+
+	first, err := resolveDeviceIdentity(
+		[]string{
+			"/sys/devices/card0",
+			"/sys/devices/renderD128",
+		},
+		renderDevIDs,
+		renderNodeIDs,
+	)
+	if err != nil {
+		t.Fatalf("resolve first device: %v", err)
+	}
+	if first.devID != "0000:01:00:0" {
+		t.Fatalf(
+			"first.devID = %q, want %q",
+			first.devID,
+			"0000:01:00:0",
+		)
+	}
+
+	_, err = resolveDeviceIdentity(
+		[]string{
+			"/sys/devices/card1",
+			"/sys/devices/renderD129",
+		},
+		renderDevIDs,
+		renderNodeIDs,
+	)
+	if err == nil {
+		t.Fatal(
+			"second device unexpectedly reused the first device's KFD identity",
+		)
+	}
+}
+
+// TestDevIdsFromTopologyOmitsPCIFunction records that the KFD-derived device
+// identity is built from the bus and device numbers only, so two functions of
+// the same PCI device share one. GetAMDGPUs relies on this when it decides
+// which physical GPU a partition belongs to.
+func TestDevIdsFromTopologyOmitsPCIFunction(t *testing.T) {
+	topoRoot := t.TempDir()
+
+	// the low three bits of location_id hold the PCI function
+	for i, locationId := range []int{0x100, 0x101} {
+		nodeDir := filepath.Join(topoRoot, "topology", "nodes", fmt.Sprint(i+2))
+		if err := os.MkdirAll(nodeDir, 0o755); err != nil {
+			t.Fatalf("Failed to create %s: %s", nodeDir, err)
+		}
+		properties := fmt.Sprintf("location_id %d\ndomain 0\ndrm_render_minor %d\n", locationId, 128+i*8)
+		if err := os.WriteFile(filepath.Join(nodeDir, "properties"), []byte(properties), 0o644); err != nil {
+			t.Fatalf("Failed to write properties: %s", err)
+		}
+	}
+
+	renderDevIds := GetDevIdsFromTopology(topoRoot)
+
+	if len(renderDevIds) != 2 {
+		t.Fatalf("GetDevIdsFromTopology returned %d entries, expect 2", len(renderDevIds))
+	}
+	if renderDevIds[128] != renderDevIds[136] {
+		t.Errorf("function 0 resolved to %q and function 1 to %q, expect the same device identity",
+			renderDevIds[128], renderDevIds[136])
+	}
+}
+
+func TestRecordParentGPU(t *testing.T) {
+	parents := make(map[string]map[string]interface{})
+	ambiguous := make(map[string]struct{})
+
+	first := map[string]interface{}{"card": 0}
+	second := map[string]interface{}{"card": 1}
+	third := map[string]interface{}{"card": 2}
+	other := map[string]interface{}{"card": 3}
+
+	if !recordParentGPU(parents, ambiguous, "0000:01:00:0", first) {
+		t.Fatal("recordParentGPU rejected the first GPU claiming an identity")
+	}
+	if !reflect.DeepEqual(parents["0000:01:00:0"], first) {
+		t.Errorf("0000:01:00:0 resolved to %v, expect the first GPU", parents["0000:01:00:0"])
+	}
+
+	// a second function of the same PCI device shares the identity
+	if recordParentGPU(parents, ambiguous, "0000:01:00:0", second) {
+		t.Error("recordParentGPU accepted a second GPU claiming the same identity")
+	}
+	if _, exists := parents["0000:01:00:0"]; exists {
+		t.Error("an identity claimed twice must not name a parent")
+	}
+
+	// a third claim must not resurrect it
+	if recordParentGPU(parents, ambiguous, "0000:01:00:0", third) {
+		t.Error("recordParentGPU accepted a third GPU claiming the same identity")
+	}
+	if _, exists := parents["0000:01:00:0"]; exists {
+		t.Error("a third claim resurrected an ambiguous identity")
+	}
+
+	// an unrelated identity is unaffected
+	if !recordParentGPU(parents, ambiguous, "0000:02:00:0", other) {
+		t.Error("recordParentGPU rejected an unambiguous identity")
+	}
+	if len(parents) != 1 {
+		t.Errorf("parent inventory holds %d entries, expect only the unambiguous one", len(parents))
+	}
+}
+
+func TestPartitionMetadataFromParent(t *testing.T) {
+	tests := []struct {
+		name            string
+		parent          map[string]interface{}
+		wantCompute     string
+		wantMemory      string
+		wantNuma        int
+		wantErrContains string
+	}{
+		{
+			name:        "complete metadata",
+			parent:      map[string]interface{}{"computePartitionType": "cpx", "memoryPartitionType": "nps4", "numaNode": 1},
+			wantCompute: "cpx", wantMemory: "nps4", wantNuma: 1,
+		},
+		{
+			name:        "NUMA node zero is valid",
+			parent:      map[string]interface{}{"computePartitionType": "spx", "memoryPartitionType": "nps1", "numaNode": 0},
+			wantCompute: "spx", wantMemory: "nps1", wantNuma: 0,
+		},
+		{
+			name:            "compute partition type missing from the map",
+			parent:          map[string]interface{}{"memoryPartitionType": "nps1", "numaNode": 0},
+			wantErrContains: "malformed partition metadata",
+		},
+		{
+			name:            "numa node of the wrong type",
+			parent:          map[string]interface{}{"computePartitionType": "spx", "memoryPartitionType": "nps1", "numaNode": "0"},
+			wantErrContains: "malformed partition metadata",
+		},
+		{
+			name:            "empty compute partition type",
+			parent:          map[string]interface{}{"computePartitionType": "", "memoryPartitionType": "nps1", "numaNode": 0},
+			wantErrContains: "no partition type",
+		},
+		{
+			name:            "empty memory partition type",
+			parent:          map[string]interface{}{"computePartitionType": "spx", "memoryPartitionType": "", "numaNode": 0},
+			wantErrContains: "no partition type",
+		},
+		{
+			name:            "no NUMA affinity",
+			parent:          map[string]interface{}{"computePartitionType": "spx", "memoryPartitionType": "nps1", "numaNode": -1},
+			wantErrContains: "no NUMA node",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compute, memory, numa, err := partitionMetadataFromParent(tt.parent)
+
+			if tt.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("partitionMetadataFromParent() error = nil, want %q", tt.wantErrContains)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf("partitionMetadataFromParent() error = %q, want substring %q", err, tt.wantErrContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("partitionMetadataFromParent() error = %v", err)
+			}
+			if compute != tt.wantCompute || memory != tt.wantMemory || numa != tt.wantNuma {
+				t.Errorf("partitionMetadataFromParent() = %q, %q, %d, want %q, %q, %d",
+					compute, memory, numa, tt.wantCompute, tt.wantMemory, tt.wantNuma)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Resolve DRM and KFD identity independently for each physical GPU and XCP candidate.
- Reject incomplete or ambiguous card/render-node identities instead of reusing fields from a previously enumerated device.
- Require both the KFD device identity and KFD node ID before publishing a candidate.
- Restrict XCP parent lookup to the physical-device inventory.
- Keep the parent inventory and the partition metadata inheritance in small pure helpers, so both are reachable from a test without a filesystem seam.
- Add hardware-independent regression tests in `amdgpu_test.go`.

## Problem

`GetAMDGPUs` currently declares `card`, `renderD`, `devID`, and `nodeId` outside both discovery loops. Those fields are overwritten only when the corresponding DRM and KFD entries are present, so a later GPU with an incomplete DRM directory or no matching KFD topology entry inherits identity fields from the previously enumerated GPU.

For example, after resolving `card0/renderD128`, a second candidate that contains `card1/renderD129` but has no KFD mapping for renderD129 is published with the first GPU's `devID` and `nodeId`.

The XCP loop has the same state-sharing problem. It also looks up parent metadata in the same `devices` map to which partitions are appended, so a later partition can select an earlier sibling rather than a physical GPU.

The parsing is unchecked as well: `name[0:4]` and `name[0:7]` panic on a `drm` entry name shorter than seven characters, and the `strconv.Atoi` errors are discarded, so a name that is not `card<digits>` yields index 0 rather than an error.

## Intentional behavior change

A physical GPU whose render node has no complete KFD topology mapping is now omitted from the returned inventory.

This is intentional fail-closed behavior. Publishing a DRM device with a missing or borrowed KFD identity can associate it with the wrong physical GPU and can corrupt allocator grouping and topology metadata.

The XCP path already requires its render node to be present in KFD topology. This change applies the same identity-validity requirement to physical candidates, and additionally requires a KFD node ID.

The KFD-derived identity is built from the bus and device numbers only (`fmt.Sprintf("%04x:%02x:%02x:0", domain, bus, dev)`), so two functions of the same PCI device share one. Both GPUs are still reported with their own card, render node and KFD node ID; only the shared identity is kept out of the parent inventory, so partitions of it are not reported. This affects a node only if it binds more than one function of a device to amdgpu.

`TestAMDGPUcountConsistent` compares the AMD card count under `/sys/class/drm` against `len(GetAMDGPUs())`. On a node where a DRM-visible GPU has no KFD topology entry those two numbers now differ, so that test would fail there. It skips on machines without AMD hardware, so CI is unaffected, but it is worth flagging as a consequence rather than leaving it to be discovered.

Because `GetAMDGPUs` is also used by the node labeller, a DRM-visible but KFD-invisible device will not be labelled by this helper. That is intentional for this focused correctness fix: the returned records carry KFD-derived compute identity consumed by downstream code, and a separate DRM-only discovery model would need a wider API design.

## Why this does not terminate the process

The missing-driver condition handled by #196 is process-wide: no valid GPU inventory can exist while the amdgpu driver is absent.

A missing KFD mapping here is device-scoped. Other GPUs on the same node may already have complete and valid identities, so terminating the process for one unresolved candidate could make valid GPUs unavailable and could create a permanent restart loop on mixed nodes. The candidate is therefore skipped with a warning while valid devices remain available.

Worth noting for anyone reaching for `Errorf` here: it would only raise the log severity, not force re-registration or restart. That needs `Fatalf`, `os.Exit`, or an error propagated up to `main`.

Runtime topology retry and reconciliation are intentionally out of scope.

## Test plan

- [x] Complete card/render/KFD identity resolves successfully
- [x] KFD node ID zero remains valid
- [x] Missing card or render node is rejected
- [x] Missing or empty KFD device identity is rejected
- [x] Missing KFD node ID is rejected
- [x] Short and unrelated DRM entry names do not panic
- [x] A connector entry such as `card0-DP-1` is not read as `card0`
- [x] A render entry with a trailing suffix is not read as a render node
- [x] A card or render index too large for an int is rejected
- [x] Conflicting card/render entries are rejected
- [x] A second unresolved device cannot inherit the first device's identity
- [x] Two PCI functions of one device resolve to the same KFD identity
- [x] An identity claimed twice is dropped from the parent inventory and is not resurrected by a third claim
- [x] An unrelated identity is unaffected by an ambiguous one
- [x] Partition metadata is rejected when malformed, empty, or without NUMA affinity
- [x] A parent NUMA node of 0 remains valid
- [x] `go test ./...` and `go vet ./...`

I checked every guard by disabling it one at a time and confirming a test fails: the invalid sentinels, the incomplete-identity check, both KFD lookups, both conflict checks, both regex anchors, the ambiguous-identity removal, and each of the three partition metadata rejections. The one guard not covered is the physical loop's skip on an unresolvable identity, which would need a filesystem injection seam to reach from a test; the resolver it calls is covered directly.

## Non-goals

- Runtime KFD topology reconciliation.
- Changes to resource naming or allocation policy.
- Changes to the Kubernetes device-plugin registration lifecycle.
- Changes to time-slicing support in #189. This patch touches only `internal/pkg/amdgpu`, so it does not overlap `main.go`, `plugin.go`, `ListAndWatch`, or `Allocate`.

Fixes: #209
