### PR TITLE
fix: score a GPU pair with no recorded interconnect as the worst case

### DIFF
--- a/internal/pkg/allocator/device.go
+++ b/internal/pkg/allocator/device.go
@@ -43,8 +43,7 @@ const (
 	xgmiLinkWeight = 10
 	// weight if GPU pair belongs to same numa node
 	sameNumaNodeWeight = 10
-	// weight if GPUs/partitions belong to different GPU.
-	// In case of full GPUs, the weight is 3
+	// weight if GPUs/partitions belong to different GPU
 	differentDevIdWeight = 20
 	// weight if GPU pair belongs to different numa node
 	differentNumaNodeWeight = 20
@@ -52,6 +51,11 @@ const (
 	pcieLinkWeight = 40
 	// weight if a pair is connected via any other link apart from XGMI or PCIE
 	otherLinkWeight = 50
+	// weight if the KFD topology records no link at all between the pair.
+	// A lower weight wins, so this has to stay above every score the constants
+	// above can add up to, otherwise an undiscovered pair would outrank a pair
+	// that is known to be connected.
+	unknownLinkWeight = differentDevIdWeight + otherLinkWeight + differentNumaNodeWeight + 1
 )
 
 type Device struct {
@@ -264,7 +268,12 @@ func addDeviceToSubsetAndUpdateWeight(subset *DeviceSet, devId, devIdx int, p2pW
 			from = devId
 			to = d
 		}
-		currentWeight = currentWeight + p2pWeights[from][to]
+		// A pair the topology says nothing about is treated as the worst case
+		weight, recorded := p2pWeights[from][to]
+		if !recorded {
+			weight = unknownLinkWeight
+		}
+		currentWeight = currentWeight + weight
 	}
 	ids = append(ids, subset.Ids...)
 	ids = append(ids, devId)

--- a/internal/pkg/allocator/device_test.go
+++ b/internal/pkg/allocator/device_test.go
@@ -19,6 +19,7 @@ package allocator
 import (
 	"fmt"
 	"slices"
+	"sort"
 	"strconv"
 	"testing"
 )
@@ -165,5 +166,106 @@ func TestGetSubsetsMethod(t *testing.T) {
 		}
 		t.Logf("Result: %v", tcase.result)
 		t.Logf("Ending Testcase %s", tcase.description)
+	}
+}
+
+// TestUnknownLinkWeightIsWorseThanAnyRecordedPair enumerates every score
+// calculatePairWeight can produce and asserts the unknown-link fallback stays
+// above all of them, so an undiscovered pair can never sort first.
+func TestUnknownLinkWeightIsWorseThanAnyRecordedPair(t *testing.T) {
+	// link types 11 and 2 are XGMI and PCIe, anything else takes otherLinkWeight
+	linkTypes := []int{11, 2, 0, 3, 99}
+	worst := 0
+
+	for _, sameDev := range []bool{true, false} {
+		for _, sameNuma := range []bool{true, false} {
+			for _, linkType := range linkTypes {
+				from := &Device{DevId: "a", NumaNode: 0}
+				to := &Device{DevId: "a", NumaNode: 0}
+				if !sameDev {
+					to.DevId = "b"
+				}
+				if !sameNuma {
+					to.NumaNode = 1
+				}
+				if w := calculatePairWeight(from, to, linkType); w > worst {
+					worst = w
+				}
+			}
+		}
+	}
+
+	if unknownLinkWeight <= worst {
+		t.Errorf("unknownLinkWeight is %d but a recorded pair can score up to %d, so an unrecorded pair would be preferred",
+			unknownLinkWeight, worst)
+	}
+}
+
+func TestAddDeviceToSubsetScoresUnrecordedPairWorst(t *testing.T) {
+	recordedWeight := sameDevIdWeight + xgmiLinkWeight + sameNumaNodeWeight
+	p2pWeights := map[int]map[int]int{2: {3: recordedWeight}}
+	base := NewDeviceSet([]int{2}, []int{0}, 0, 0)
+
+	tests := []struct {
+		name       string
+		devId      int
+		expectAdds int
+	}{
+		{name: "recorded pair", devId: 3, expectAdds: recordedWeight},
+		{name: "pair absent from the row", devId: 99, expectAdds: unknownLinkWeight},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addDeviceToSubsetAndUpdateWeight(base, tt.devId, 0, p2pWeights)
+			if got.TotalWeight != tt.expectAdds {
+				t.Errorf("TotalWeight = %d, expect %d", got.TotalWeight, tt.expectAdds)
+			}
+		})
+	}
+
+	// The whole row missing must behave like a missing entry in an existing row.
+	noRow := addDeviceToSubsetAndUpdateWeight(NewDeviceSet([]int{7}, []int{0}, 0, 0), 8, 0, p2pWeights)
+	if noRow.TotalWeight != unknownLinkWeight {
+		t.Errorf("TotalWeight = %d for a pair with no row at all, expect %d", noRow.TotalWeight, unknownLinkWeight)
+	}
+}
+
+// TestCandidateSubsetsPreferRecordedLinks covers a topology split into two XGMI
+// islands with nothing recorded between them, which is where an unrecorded pair
+// scoring zero used to win.
+func TestCandidateSubsetsPreferRecordedLinks(t *testing.T) {
+	devs := []*Device{
+		{Id: "gpu0", NodeId: 2, DevId: "0", NumaNode: 0},
+		{Id: "gpu1", NodeId: 3, DevId: "1", NumaNode: 0},
+		{Id: "gpu2", NodeId: 4, DevId: "2", NumaNode: 1},
+		{Id: "gpu3", NodeId: 5, DevId: "3", NumaNode: 1},
+	}
+	linked := differentDevIdWeight + xgmiLinkWeight + sameNumaNodeWeight
+	p2pWeights := map[int]map[int]int{
+		2: {3: linked}, // island A
+		4: {5: linked}, // island B
+	}
+
+	subsets, err := getCandidateDeviceSubsets(groupPartitionsByDevId(devs), devs, devs, nil, 2, p2pWeights)
+	if err != nil {
+		t.Fatalf("getCandidateDeviceSubsets failed: %s", err)
+	}
+	if len(subsets) == 0 {
+		t.Fatal("getCandidateDeviceSubsets returned no candidate")
+	}
+
+	best := subsets[0]
+	for _, subset := range subsets {
+		if subset.TotalWeight < best.TotalWeight {
+			best = subset
+		}
+	}
+
+	sort.Ints(best.Ids)
+	withinIsland := (best.Ids[0] == 2 && best.Ids[1] == 3) || (best.Ids[0] == 4 && best.Ids[1] == 5)
+	if !withinIsland {
+		t.Errorf("best subset is %v with weight %d, expect an XGMI connected pair from one island",
+			best.Ids, best.TotalWeight)
 	}
 }


### PR DESCRIPTION
Fixes #210.

`BestEffortPolicy` sums the pairwise weights of a candidate subset and `Allocate` keeps the one with the lowest total. `addDeviceToSubsetAndUpdateWeight` read `p2pWeights[from][to]` straight out of the map, so a pair that `fetchAllPairWeights` found no `io_links` or `p2p_links` entry for contributed the zero value.

Lower wins, so a pair the topology says nothing about outranked every pair known to be connected. That is not a small bias: the weight constants put any real pair between 30 and 90, so a missing entry lands at a score no discovered pair can reach and always sorts first.

## The fix

The lookup now uses the comma-ok form and substitutes `unknownLinkWeight` when the pair is absent:

```go
weight, recorded := p2pWeights[from][to]
if !recorded {
	weight = unknownLinkWeight
}
```

`unknownLinkWeight` is derived from the existing constants rather than written as a literal:

```go
unknownLinkWeight = differentDevIdWeight + otherLinkWeight + differentNumaNodeWeight + 1
```

so it stays correct if someone retunes the weights. A missing row and a missing entry within an existing row both take this path, since reading a key out of a nil map yields the same `ok == false`.

## Tests

`TestUnknownLinkWeightIsWorseThanAnyRecordedPair` enumerates every combination `calculatePairWeight` can return, across all three link-type branches and both the same/different GPU and NUMA cases, and asserts the fallback stays above the highest of them. That is the invariant the fix rests on, so it seemed worth pinning rather than asserting a specific number.

`TestCandidateSubsetsPreferRecordedLinks` builds a four-GPU topology split into two XGMI islands with nothing recorded across them, and asserts the lowest-scoring subset stays within an island.

I checked the tests fail against the old behaviour by putting the plain map read back, and also that they fail if `unknownLinkWeight` is set to 0 or to exactly the worst recorded score rather than one above it.

Existing tests are unaffected: every GPU pair in all three topologies under `testdata/` already has an entry, which is also why this went unnoticed.

To be straight about the limits here, I have no machine whose KFD topology omits a GPU pair. The island example is a hand-built `p2pWeights` map fed to `getCandidateDeviceSubsets`, not something I observed in the field. What the code shows is that there is no floor for a missing pair, and that the fixtures being fully connected is why nothing caught it.

## Note

This also drops the comment on `differentDevIdWeight` saying "In case of full GPUs, the weight is 3", since the constant is 20. If that comment was describing intended behaviour rather than a stale value, say so and I will leave it alone or open something separate.
