### PR TITLE
fix: enumerate candidate device subsets as combinations

### DIFF
--- a/internal/pkg/allocator/device.go
+++ b/internal/pkg/allocator/device.go
@@ -351,6 +351,30 @@ func filterPartitions(partitions map[string]*DevicePartitions, available, requir
 	return outset
 }
 
+// parentSetKey identifies a partially built subset by the GPU groups it covers.
+// Groups that were taken whole are order independent, so they are sorted, while
+// the group the subset is truncated on decides which devices it ends up with
+// and is kept separate. Two expansions with the same key produce the same set
+// of devices and only differ in the order they were reached.
+func parentSetKey(wholeGroups []int, truncatedGroup int) string {
+	sorted := make([]int, len(wholeGroups))
+	copy(sorted, wholeGroups)
+	sort.Ints(sorted)
+
+	var key strings.Builder
+	for i, group := range sorted {
+		if i > 0 {
+			key.WriteByte(',')
+		}
+		key.WriteString(strconv.Itoa(group))
+	}
+	if truncatedGroup >= 0 {
+		key.WriteByte('|')
+		key.WriteString(strconv.Itoa(truncatedGroup))
+	}
+	return key.String()
+}
+
 func getCandidateDeviceSubsets(allDevPartitions map[string]*DevicePartitions, total, available, required []*Device, size int, p2pWeights map[int]map[int]int) ([]*DeviceSet, error) {
 	if size <= 0 {
 		return []*DeviceSet{}, fmt.Errorf("subset size should be positive integer")
@@ -403,6 +427,9 @@ func getCandidateDeviceSubsets(allDevPartitions map[string]*DevicePartitions, to
 	}
 	// for each subsetsTemp, we loop over all the devPartitions
 	// pick partitions from other gpu until the subsetsTemp has requested number of gpus/partitions
+	// expanded records the group combinations already grown, so a combination is
+	// only expanded once instead of once per order it can be reached in
+	expanded := make(map[string]struct{})
 	for {
 		if len(subsetsTemp) == 0 {
 			break
@@ -423,6 +450,18 @@ func getCandidateDeviceSubsets(allDevPartitions map[string]*DevicePartitions, to
 			var parentIds []int
 			parentIds = append(parentIds, currentSubset.ParentIds...)
 			parentIds = append(parentIds, idx)
+
+			// this gpu is taken whole unless it overshoots the requested size,
+			// in which case which gpu got truncated decides the devices picked
+			key := parentSetKey(parentIds, -1)
+			if len(currentSubset.Ids)+len(devPartitions[idx].Ids) > newSize {
+				key = parentSetKey(currentSubset.ParentIds, idx)
+			}
+			if _, seen := expanded[key]; seen {
+				continue
+			}
+			expanded[key] = struct{}{}
+
 			devset := NewDeviceSet(currentSubset.Ids, parentIds, currentSubset.TotalWeight, currentSubset.LastIdx)
 			for _, id := range devPartitions[idx].Ids {
 				devset = addDeviceToSubsetAndUpdateWeight(devset, id, idx, p2pWeights)

--- a/internal/pkg/allocator/device_test.go
+++ b/internal/pkg/allocator/device_test.go
@@ -19,8 +19,10 @@ package allocator
 import (
 	"fmt"
 	"slices"
+	"sort"
 	"strconv"
 	"testing"
+	"time"
 )
 
 type testInfo struct {
@@ -166,4 +168,166 @@ func TestGetSubsetsMethod(t *testing.T) {
 		t.Logf("Result: %v", tcase.result)
 		t.Logf("Ending Testcase %s", tcase.description)
 	}
+}
+
+func (ti *testInfo) getSyntheticDevices(gpuCount, partitionsPerGPU int) []*Device {
+	devs := make([]*Device, 0, gpuCount*partitionsPerGPU)
+	nodeId := 2
+	for gpu := 0; gpu < gpuCount; gpu++ {
+		for partition := 0; partition < partitionsPerGPU; partition++ {
+			id := fmt.Sprintf("amdgpu_xcp_%d", gpu*partitionsPerGPU+partition)
+			if partition == 0 {
+				id = fmt.Sprintf("gpu%d", gpu)
+			}
+			devs = append(devs, &Device{
+				Id:       id,
+				NodeId:   nodeId,
+				NumaNode: gpu % 2,
+				DevId:    strconv.Itoa(gpu),
+			})
+			nodeId++
+		}
+	}
+	return devs
+}
+
+// TestCandidateSubsetsAreCombinations checks that a set of devices is offered
+// as a candidate once, not once per order the enumeration can reach it in.
+func TestCandidateSubsetsAreCombinations(t *testing.T) {
+	tests := []struct {
+		name             string
+		gpuCount         int
+		partitionsPerGPU int
+		size             int
+		expectCount      int
+	}{
+		// C(4,2) rather than P(4,2) = 12
+		{name: "4 whole gpus, allocate 2", gpuCount: 4, partitionsPerGPU: 1, size: 2, expectCount: 6},
+		// C(8,7) rather than P(8,7) = 40320
+		{name: "8 gpus of 8 partitions, allocate 56", gpuCount: 8, partitionsPerGPU: 8, size: 56, expectCount: 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := &testInfo{}
+			devs := ti.getSyntheticDevices(tt.gpuCount, tt.partitionsPerGPU)
+			subsets, err := getCandidateDeviceSubsets(
+				groupPartitionsByDevId(devs), devs, devs, nil, tt.size, map[int]map[int]int{})
+			if err != nil {
+				t.Fatalf("getCandidateDeviceSubsets failed: %s", err)
+			}
+			if len(subsets) != tt.expectCount {
+				t.Errorf("got %d candidate subsets, expect %d", len(subsets), tt.expectCount)
+			}
+
+			seen := make(map[string]struct{}, len(subsets))
+			for _, subset := range subsets {
+				ids := make([]int, len(subset.Ids))
+				copy(ids, subset.Ids)
+				sort.Ints(ids)
+				key := fmt.Sprint(ids)
+				if _, duplicate := seen[key]; duplicate {
+					t.Errorf("device set %v was offered more than once", ids)
+				}
+				seen[key] = struct{}{}
+				if len(subset.Ids) != tt.size {
+					t.Errorf("candidate %v holds %d devices, expect %d", ids, len(subset.Ids), tt.size)
+				}
+			}
+		})
+	}
+}
+
+// TestCandidateSubsetsCoverEveryCombination checks the dedup drops only
+// duplicates, by comparing against every combination of whole GPUs that can
+// satisfy the request.
+func TestCandidateSubsetsCoverEveryCombination(t *testing.T) {
+	ti := &testInfo{}
+	devs := ti.getSyntheticDevices(5, 1)
+	subsets, err := getCandidateDeviceSubsets(
+		groupPartitionsByDevId(devs), devs, devs, nil, 3, map[int]map[int]int{})
+	if err != nil {
+		t.Fatalf("getCandidateDeviceSubsets failed: %s", err)
+	}
+
+	got := make(map[string]struct{}, len(subsets))
+	for _, subset := range subsets {
+		ids := make([]int, len(subset.Ids))
+		copy(ids, subset.Ids)
+		sort.Ints(ids)
+		got[fmt.Sprint(ids)] = struct{}{}
+	}
+
+	// node ids are 2..6, so every 3 of them must be offered
+	for i := 2; i <= 6; i++ {
+		for j := i + 1; j <= 6; j++ {
+			for k := j + 1; k <= 6; k++ {
+				key := fmt.Sprint([]int{i, j, k})
+				if _, exists := got[key]; !exists {
+					t.Errorf("combination %s is missing from the candidates", key)
+				}
+			}
+		}
+	}
+	if len(got) != 10 {
+		t.Errorf("got %d distinct combinations, expect C(5,3) = 10", len(got))
+	}
+}
+
+// TestCandidateSubsetsScaleOnLargePartitionedNode covers a node larger than the
+// fixtures in testdata, where the permutational walk did not terminate.
+func TestCandidateSubsetsScaleOnLargePartitionedNode(t *testing.T) {
+	ti := &testInfo{}
+	devs := ti.getSyntheticDevices(12, 8)
+
+	done := make(chan int, 1)
+	go func() {
+		subsets, _ := getCandidateDeviceSubsets(
+			groupPartitionsByDevId(devs), devs, devs, nil, 64, map[int]map[int]int{})
+		done <- len(subsets)
+	}()
+
+	select {
+	case count := <-done:
+		// C(12,8) = 495
+		if count != 495 {
+			t.Errorf("got %d candidate subsets for 12 gpus of 8 partitions, expect C(12,8) = 495", count)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("enumerating candidates for 96 devices did not finish within 10s")
+	}
+}
+
+// TestCandidateSubsetsWithTruncatedGroup covers a request that does not divide
+// evenly into whole GPUs, where the gpu that gets truncated changes which
+// devices the candidate holds and must therefore stay distinct.
+func TestCandidateSubsetsWithTruncatedGroup(t *testing.T) {
+	ti := &testInfo{}
+	devs := ti.getSyntheticDevices(4, 4) // node ids 2..17, four gpus of four
+	subsets, err := getCandidateDeviceSubsets(
+		groupPartitionsByDevId(devs), devs, devs, nil, 10, map[int]map[int]int{})
+	if err != nil {
+		t.Fatalf("getCandidateDeviceSubsets failed: %s", err)
+	}
+
+	seen := make(map[string]struct{}, len(subsets))
+	for _, subset := range subsets {
+		ids := make([]int, len(subset.Ids))
+		copy(ids, subset.Ids)
+		sort.Ints(ids)
+		key := fmt.Sprint(ids)
+		if _, duplicate := seen[key]; duplicate {
+			t.Errorf("device set %v was offered more than once", ids)
+		}
+		seen[key] = struct{}{}
+		if len(subset.Ids) != 10 {
+			t.Errorf("candidate %v holds %d devices, expect 10", ids, len(subset.Ids))
+		}
+	}
+
+	// two gpus whole plus two of a third, so the truncated gpu must vary
+	if len(seen) < 2 {
+		t.Errorf("got %d distinct candidates, expect the truncated gpu to vary", len(seen))
+	}
+	t.Logf("%d distinct candidates for 10 of 16 devices across 4 gpus", len(seen))
 }


### PR DESCRIPTION
Fixes #211.

`getCandidateDeviceSubsets` grows a partially filled subset by appending every gpu group not already in it, but nothing records which *set* of groups a subset covers. The same set of devices is therefore reached once per order it can be built in, so the candidate list holds permutations where combinations would do. For four whole gpus and a request of two, every pair shows up twice; for eight gpus of eight partitions and a request of 56 the walk produces 40320 candidates for what is C(8,7) = 8 distinct choices.

## The fix

An expansion is now keyed by the groups it covers. Groups taken whole are order independent, so they are sorted into the key; a group the subset is truncated on decides which devices are picked, so it is kept distinct:

```go
key := parentSetKey(parentIds, -1)
if len(currentSubset.Ids)+len(devPartitions[idx].Ids) > newSize {
	key = parentSetKey(currentSubset.ParentIds, idx)
}
if _, seen := expanded[key]; seen {
	continue
}
```

The `>` rather than `>=` matters: a group that exactly fills the request is taken whole, so which group it was does not change the devices picked and does not belong in the key. Getting that wrong leaves 3960 candidates where 495 are distinct, which is what the 12-gpu test asserts against.

Both keys describe the same device set for every order that reaches it, and the weight is a sum of symmetric pairwise scores, so the total does not depend on insertion order and the winning subset is unchanged. The expectations in `TestBestPolicyAllocator` pass untouched.

## Measurements

Through `BestEffortPolicy.Allocate` against the `testdata/topo-mi300-cpx` fixture, 8 gpus of 8 partitions:

```
size    before      after
16      420µs       283µs
24      3.53ms      802µs
32      26.0ms      2.22ms
40      128ms       2.31ms
48      493ms       2.46ms
56      1.10s       3.97ms
```

And candidate counts, with the last two rows on synthetic device lists since the repo has no fixture that large:

```
 8 gpu x 8 partition, allocate 56:   484ms / 40320  ->   1ms / 8
12 gpu x 8 partition, allocate 64:   did not finish -> 41ms / 495
16 gpu x 8 partition, allocate 96:   not attempted  -> 847ms / 1820
```

I have not seen this on hardware; I went looking after noticing the duplicate pairs in the candidate list.

## Tests

- `TestCandidateSubsetsAreCombinations` asserts the count is C(n,k) and that no device set is offered twice.
- `TestCandidateSubsetsCoverEveryCombination` enumerates every combination of five gpus taken three at a time and asserts all ten are present, so the dedup drops duplicates only.
- `TestCandidateSubsetsWithTruncatedGroup` covers a request that does not divide evenly into whole gpus, where the truncated group changes the devices picked and must stay distinct.
- `TestCandidateSubsetsScaleOnLargePartitionedNode` covers 12 gpus of 8 partitions, which did not terminate before.

## Note

This only removes redundant work; it does not bound the worst case. Cost still grows with the number of free gpu groups, and the slowest case remains a node with everything available. If you would rather also cap the candidate count or exit early once a subset reaches the best achievable score, I am happy to add that here or separately.
