### PR TITLE
fix(labeller): drop privileged and CAP_SYS_ADMIN from node-labeller

### DIFF
--- a/helm/amd-gpu/values.yaml
+++ b/helm/amd-gpu/values.yaml
@@ -23,12 +23,14 @@ lbl:
   serviceAccount:
     annotations: {}
   securityContext:
-    privileged: true # Needed for /dev
+    # The labeller reads GPU properties from /sys and opens the DRM device nodes
+    # (/dev/kfd, /dev/dri) via libdrm. Those device nodes are mounted read-only by
+    # the DaemonSet, which is sufficient - no privilege or capabilities are needed.
+    privileged: false
+    allowPrivilegeEscalation: false
     capabilities:
       drop:
         - ALL
-      add:
-        - CAP_SYS_ADMIN
     readOnlyRootFilesystem: false # true if -logtostderr flag set in labeller
   # If you do want to specify resources, uncomment the following lines, 
   # adjust them as necessary, and remove the curly braces after 'resources:'.


### PR DESCRIPTION
## Summary

The node-labeller DaemonSet ran with `privileged: true` **plus** `CAP_SYS_ADMIN`. It needs neither:

- It reads GPU properties from `/sys`, and opens the DRM device nodes (`/dev/kfd`, `/dev/dri`) via libdrm (`GetCardFamilyName`, `GetFirmwareVersions`, `GetCardProductName` → `openAMDGPU`).
- The DaemonSet **already mounts those device nodes read-only**, which is sufficient — the device nodes are group-owned (`root:video` / `root:render`), not privilege-gated.
- `privileged: true` already implies all capabilities, so the explicit `CAP_SYS_ADMIN` was redundant.

Sets `privileged: false`, `allowPrivilegeEscalation: false`, keeps `capabilities.drop: [ALL]`. **No template change needed.**

## Validation

Validated on an MI300 node (16 GPUs, amdgpu loaded) using the published labeller image (`rocm/k8s-device-plugin:labeller-1.31.0.9`) with the GPU-probing flags (`-family -firmware`):

| Config | libdrm device inits | firmware queries | open/permission errors |
|---|---|---|---|
| `--privileged` (current) | 16 | 24 | 0 |
| `--device /dev/kfd --device /dev/dri --cap-drop ALL --security-opt no-new-privileges` | **16** | **24** | **0** |

Both configurations probe all 16 physical GPUs identically (the "not an AMD GPU" messages correspond to empty card slots among the 64 `/dev/dri` entries). `helm lint` passes and the rendered DaemonSet carries the hardened securityContext with device mounts intact.

## Context

Related to Mythos finding SEC-00207. Note the finding attributes this to the *device-plugin* DaemonSet, but that component already runs non-privileged with `capabilities.drop: [ALL]`; the privileged workload is the labeller, which this change hardens.

Cherry-picked from the equivalent change merged in the internal mirror.