### PR TITLE
fix(security): port Mythos fixes from the pensando fork (KUBE-28/29/37/38)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,17 @@ updates:
       - "documentation"
     reviewers:
       - "samjwu"
+    # Wait a week after release so a version that gets yanked or immediately
+    # patched is not pulled in. zizmor's dependabot-cooldown audit runs over the
+    # whole file, so this is required on every entry, not just the new one.
+    cooldown:
+      default-days: 7
+  # Keeps the SHA pins in .github/workflows current; without this they would be
+  # pinned and then quietly rot.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   build-images:
     runs-on: ubuntu-latest
@@ -23,7 +26,9 @@ jobs:
     name: build (${{ matrix.name }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Build ${{ matrix.name }}
         run: make ${{ matrix.target }}

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -6,14 +6,23 @@ on:
     branches:
       - master
 
+# chart-releaser pushes the packaged charts and creates a release; contents is
+# the only elevated scope it needs. Without this block GITHUB_TOKEN defaults to
+# write-all and is handed to a third-party action below via CR_TOKEN.
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          # Keep GITHUB_TOKEN out of .git/config, where any later step could
+          # read it. chart-releaser authenticates with CR_TOKEN instead.
+          persist-credentials: false
 
       - name: Configure Git
         run: |
@@ -21,12 +30,12 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.16.4
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           # The charts directory
           charts_dir: helm

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,30 @@
+name: Lint Workflows
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          # Print findings to the console and fail the job on any finding,
+          # instead of uploading to GitHub Advanced Security (non-blocking).
+          advanced-security: false

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,9 @@ on:
       - release-*
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: unit-tests-${{ github.ref }}
   cancel-in-progress: true
@@ -17,13 +20,15 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libhwloc-dev libdrm-dev
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG GOLANG_BASE_IMG=golang:1.26.5-alpine3.23
 ARG ALPINE_BASE_IMG=alpine:3.23.5
 FROM ${GOLANG_BASE_IMG}
 RUN apk --no-cache add git pkgconfig build-base libdrm-dev
-RUN apk --no-cache add hwloc-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+RUN apk --no-cache add hwloc-dev --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN mkdir -p /go/src/github.com/ROCm/k8s-device-plugin
 ADD . /go/src/github.com/ROCm/k8s-device-plugin
 WORKDIR /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-device-plugin
@@ -29,7 +29,7 @@ LABEL \
     org.opencontainers.image.vendor="Advanced Micro Devices, Inc." \
     org.opencontainers.image.licenses="Apache-2.0"
 RUN apk --no-cache add ca-certificates libdrm
-RUN apk --no-cache add hwloc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+RUN apk --no-cache add hwloc --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 WORKDIR /root/
 COPY --from=0 /go/bin/k8s-device-plugin .
 CMD ["./k8s-device-plugin", "-logtostderr=true", "-stderrthreshold=INFO", "-v=5"]

--- a/ubi-dp.Dockerfile
+++ b/ubi-dp.Dockerfile
@@ -19,9 +19,12 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
     rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official && \
     dnf install git pkgconfig gcc gcc-c++ make glibc-devel binutils libdrm-devel hwloc-devel wget tar gzip -y && \
     dnf clean all
-RUN wget https://go.dev/dl/go1.26.5.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.26.5.linux-amd64.tar.gz && \
-    rm go1.26.5.linux-amd64.tar.gz
+ARG GO_VERSION=1.26.5
+ARG GO_SHA256=5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053
+RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
+    echo "${GO_SHA256}  go${GO_VERSION}.linux-amd64.tar.gz" | sha256sum -c - && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
+    rm go${GO_VERSION}.linux-amd64.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH="/go"
 RUN mkdir -p /go/src/github.com/ROCm/k8s-device-plugin

--- a/ubi-labeller.Dockerfile
+++ b/ubi-labeller.Dockerfile
@@ -19,9 +19,12 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
     rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official && \
     dnf install git pkgconfig gcc gcc-c++ make glibc-devel binutils libdrm-devel wget tar gzip -y && \
     dnf clean all
-RUN wget https://go.dev/dl/go1.26.5.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.26.5.linux-amd64.tar.gz && \
-    rm go1.26.5.linux-amd64.tar.gz
+ARG GO_VERSION=1.26.5
+ARG GO_SHA256=5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053
+RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
+    echo "${GO_SHA256}  go${GO_VERSION}.linux-amd64.tar.gz" | sha256sum -c - && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
+    rm go${GO_VERSION}.linux-amd64.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH="/go"
 RUN mkdir -p /go/src/github.com/ROCm/k8s-device-plugin


### PR DESCRIPTION
## Why

Mythos scanned **this** repository — KUBE-38 cites `ROCm/k8s-device-plugin@dea1db13f051` — but four of its findings were remediated only in the `pensando/k8s-device-plugin` fork. All four read *Implemented* in Jira while the finding is still live here.

| Ticket | Finding | here |
|---|---|---|
| KUBE-28 | Actions on mutable tag refs | 6 unpinned refs |
| KUBE-29 | No `permissions:` → write-all token | 3 workflows, none |
| KUBE-37 | `apk` over plaintext HTTP | 2 occurrences |
| KUBE-38 | Go tarball, no SHA-256 | both UBI images |

KUBE-39 and KUBE-45 are already fixed here and are untouched.

## What changed

**KUBE-29** — `helm-chart-release.yml` declared no permissions, so `GITHUB_TOKEN` defaulted to write-all and was passed to a third-party action via `CR_TOKEN`. Scoped to `contents: write`, the only elevated scope `chart-releaser` needs. `ci.yml` and `unit-tests.yml` get `contents: read`.

**KUBE-28** — pinned all six action refs to immutable SHAs with version comments, and added the `github-actions` Dependabot ecosystem so they don't rot. The existing pip entry gains a `cooldown` too — zizmor's `dependabot-cooldown` audit reads the whole file.

**KUBE-37** — `Dockerfile` fetched the Alpine edge community repo over plaintext HTTP; a network position between the build and the CDN could substitute the `hwloc` packages. Now `https`.

**KUBE-38** — the UBI images downloaded the Go toolchain and untarred it unverified. A substituted toolchain backdoors every binary it compiles, and those run on every node. Added `ARG GO_VERSION` / `ARG GO_SHA256` and a `sha256sum -c` gate.

`lint-actions.yml` is new: zizmor, blocking, on any workflow change, so none of this regresses.

## Note on the chosen pin versions

The pins match what runs in the pensando fork, **not** the SHAs of the tags currently referenced here.

`helm-chart-release.yml` is a production release path that a PR cannot exercise, and `persist-credentials: false` behaves differently across `checkout` majors — v7 provisions credentials through a scoped include, v4 omits them outright, which `chart-releaser` needs for its push to the pages branch. Rather than ship a combination nobody has run, this takes the one proven in production since July: checkout v7.0.1, setup-helm v5.0.1, chart-releaser v1.7.0.

## Verification

**zizmor**, run locally against both states:

| | findings |
|---|---|
| before | **20** — 6 `unpinned-uses`, 3 `excessive-permissions`, 3 `artipacked`, + suppressed (exit 14) |
| after | **0** (exit 0) |

**Builds** — all four images build (`build-ubi-device-plugin`, `build-ubi-labeller`, `build-device-plugin`, plus `build-labeller` via CI).

**The checksum gate, tested in both directions** — a passing build alone wouldn't prove the gate is live:

```
NEGATIVE  wrong GO_SHA256  -> exit 1
          go1.26.5.linux-amd64.tar.gz: FAILED
          sha256sum: WARNING: 1 computed checksum did NOT match

POSITIVE  committed value  -> exit 0
          go1.26.5.linux-amd64.tar.gz: OK
```

The checksum was verified against go.dev's release JSON rather than copied from the fork on trust.

## Scope

Go stays at **1.26.5** here. The bump to 1.26.7 (7 stdlib CVEs) and the `x/net` / `x/text` / `grpc` module CVEs follow in a separate PR, so that this one isn't buried under a regenerated `vendor/` tree.