### PR TITLE
fix(security): install the Go toolchain from the official image (KUBE-38)

### DIFF
--- a/ubi-dp.Dockerfile
+++ b/ubi-dp.Dockerfile
@@ -11,20 +11,21 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+ARG GO_VERSION=1.26.7
+
+# KUBE-38: the toolchain is integrity-checked on pull, since Docker verifies
+# every layer against its digest in the image manifest.
+FROM golang:${GO_VERSION} AS gotoolchain
+
 FROM registry.access.redhat.com/ubi9/ubi:9.8 as builder
 USER root
 RUN dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/ && \
     dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/ && \
     rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official && \
-    dnf install git pkgconfig gcc gcc-c++ make glibc-devel binutils libdrm-devel hwloc-devel wget tar gzip -y && \
+    dnf install git pkgconfig gcc gcc-c++ make glibc-devel binutils libdrm-devel hwloc-devel -y && \
     dnf clean all
-ARG GO_VERSION=1.26.7
-ARG GO_SHA256=ffb5f8de10c62550dfddab66b36b57030721e0a44a3218e9e1181d7b59f121ca
-RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
-    echo "${GO_SHA256}  go${GO_VERSION}.linux-amd64.tar.gz" | sha256sum -c - && \
-    tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
-    rm go${GO_VERSION}.linux-amd64.tar.gz
+COPY --from=gotoolchain /usr/local/go /usr/local/go
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH="/go"
 RUN mkdir -p /go/src/github.com/ROCm/k8s-device-plugin

--- a/ubi-labeller.Dockerfile
+++ b/ubi-labeller.Dockerfile
@@ -11,20 +11,21 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+ARG GO_VERSION=1.26.7
+
+# KUBE-38: the toolchain is integrity-checked on pull, since Docker verifies
+# every layer against its digest in the image manifest.
+FROM golang:${GO_VERSION} AS gotoolchain
+
 FROM registry.access.redhat.com/ubi9/ubi:9.8 as builder
 USER root
 RUN dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/ && \
     dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/ && \
     rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official && \
-    dnf install git pkgconfig gcc gcc-c++ make glibc-devel binutils libdrm-devel wget tar gzip -y && \
+    dnf install git pkgconfig gcc gcc-c++ make glibc-devel binutils libdrm-devel -y && \
     dnf clean all
-ARG GO_VERSION=1.26.7
-ARG GO_SHA256=ffb5f8de10c62550dfddab66b36b57030721e0a44a3218e9e1181d7b59f121ca
-RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
-    echo "${GO_SHA256}  go${GO_VERSION}.linux-amd64.tar.gz" | sha256sum -c - && \
-    tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
-    rm go${GO_VERSION}.linux-amd64.tar.gz
+COPY --from=gotoolchain /usr/local/go /usr/local/go
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH="/go"
 RUN mkdir -p /go/src/github.com/ROCm/k8s-device-plugin


### PR DESCRIPTION
> #222 has merged; this is rebased onto master and is now a single commit touching two Dockerfiles.

## Why

The UBI builders fetch the Go tarball with `wget` and verify it against a `GO_SHA256` kept alongside `GO_VERSION`. That satisfies KUBE-38, but the checksum has to be regenerated by hand on every bump, and a stale one fails the build at `sha256sum -c`.

```diff
-ARG GO_SHA256=ffb5f8de10c62550dfddab66b36b57030721e0a44a3218e9e1181d7b59f121ca
-RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
-    echo "${GO_SHA256}  go${GO_VERSION}.linux-amd64.tar.gz" | sha256sum -c - && \
-    tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
-    rm go${GO_VERSION}.linux-amd64.tar.gz
+FROM golang:${GO_VERSION} AS gotoolchain
...
+COPY --from=gotoolchain /usr/local/go /usr/local/go
```

Docker resolves the tag to a manifest and verifies every layer against its digest on pull, so the toolchain remains integrity-checked with nothing to maintain by hand. KUBE-38's description named this as its preferred remediation.

`wget`, `tar` and `gzip` come out of the builders — they were installed only for that tarball.

## The trade-off

A checksum in the Dockerfile can't be altered by a hostile registry or intercepting proxy; a tag can be repointed. The same exposure already applies to `registry.access.redhat.com/ubi9/ubi:9.8` in these files, so the toolchain joins an existing trust anchor rather than adding a new one — anyone able to substitute the base OS already owns the build.

Pinning `golang@sha256:...` would close that gap, at the cost of a digest to regenerate on every bump, which is the problem this removes.

## Verification

Cold cache, both images rebuilt from scratch:

- `build-ubi-device-plugin`, `build-ubi-labeller` — both OK
- builder reports `golang:1.26.7`
- device-plugin binary resolves `libdrm.so.2`, `libdrm_amdgpu.so.1`, `libhwloc.so.15` — cgo links against UBI's libraries, not the golang image's
- Trivy: **0** HIGH/CRITICAL in both

Also confirmed separately that a Debian-built toolchain compiles cgo correctly under UBI9 against UBI's own gcc and glibc.
