### PR TITLE
fix(labeller): restore the 738E AMD Instinct MI100 device ID

### DIFF
--- a/cmd/k8s-node-labeller/amdgpu.ids
+++ b/cmd/k8s-node-labeller/amdgpu.ids
@@ -550,6 +550,7 @@
 7362,	C1,	AMD Radeon Pro V540
 7362,	C3,	AMD Radeon Pro V520
 738C,	01,	AMD Instinct MI100
+738E,	01,	AMD Instinct MI100
 73A1,	00,	AMD Radeon Pro V620
 73A3,	00,	AMD Radeon Pro W6800
 73A5,	C0,	AMD Radeon RX 6950 XT


### PR DESCRIPTION
The labeller has not identified the `738E` AMD Instinct MI100 SKU since #203.

## What happened

Before #203, both labeller Dockerfiles appended eight entries to `amdgpu.ids` at build time, including:

```
RUN echo "738E,   01, AMD Instinct MI100" >> .../amdgpu.ids
```

#203 replaced the build-time fetch and those eight `RUN echo` lines with a vendored `cmd/k8s-node-labeller/amdgpu.ids`. Six of the eight were folded into that file, and a seventh (`744A`) was already carried by upstream libdrm. `738E` was neither — it is absent from upstream libdrm and from the vendored copy, so it has been missing since that change.

This is a distinct device from `738C`, which upstream does carry under the same product name:

```
738C,	01,	AMD Instinct MI100
738E,	01,	AMD Instinct MI100     <-- restored by this PR
73A1,	00,	AMD Radeon Pro V620
```

## The change

One line, in device-id order and the file's tab-separated format.

## Verification

- Both labeller images build (`build-labeller`, `build-ubi-labeller`)
- Both ship the entry in `/usr/share/libdrm/amdgpu.ids`

Also confirmed the vendored file is otherwise complete: every entry in current upstream libdrm is already present in it, so `738E` is the only gap.
