### PR TITLE
fix(helm): bump chart version to 0.22.0 to unblock chart releases

### DIFF
--- a/helm/amd-gpu/Chart.yaml
+++ b/helm/amd-gpu/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - gpu
 
 kubeVersion: ">= 1.18.0-0"
-version: 0.21.0
+version: 0.22.0
 appVersion: "1.31.0.9"
 
 dependencies:

--- a/helm/amd-gpu/README.md
+++ b/helm/amd-gpu/README.md
@@ -1,6 +1,6 @@
 # AMD GPU Helm Chart
 
-![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.31.0.9](https://img.shields.io/badge/AppVersion-1.31.0.9-informational?style=flat-square)
+![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.31.0.9](https://img.shields.io/badge/AppVersion-1.31.0.9-informational?style=flat-square)
 
 A Helm chart for deploying Kubernetes AMD GPU device plugin
 


### PR DESCRIPTION
The **Release Helm Charts** workflow has failed on every push to `master` since 2026-08-24 — most recently [run 33657183575](https://github.com/ROCm/k8s-device-plugin/actions/runs/33657183575).

## Root cause

```
Error: error creating GitHub release amd-gpu-helm-0.21.0:
POST https://api.github.com/repos/ROCm/k8s-device-plugin/releases: 422 Validation Failed
[{Resource:Release Field:tag_name Code:already_exists Message:}]
```

1. `amd-gpu-helm-0.21.0` was released on **2025-12-24** (commit e7b9edac).
2. Commit 0d25e062 (#217, "drop privileged and CAP_SYS_ADMIN from node-labeller") changed `helm/amd-gpu/values.yaml` on **2026-08-24** but left `version: 0.21.0` in `Chart.yaml`.
3. `chart-releaser` diffs `helm/` against the latest tag, now sees a changed chart, repackages it as `amd-gpu-0.21.0.tgz`, and collides with the existing release tag.

Runs before 2026-08-24 were passing only vacuously — `cr` logged `Nothing to do. No chart changes detected.` and exited early.

## Fix

Bump the chart to `0.22.0`. This is the correct fix rather than setting `skip_existing: true` on the action: the labeller hardening is a real chart change that consumers have never received, and `skip_existing` would turn CI green while silently dropping it forever.

**Why minor, not patch:** no values keys were added or removed, but the default runtime posture of the node-labeller DaemonSet changes (`privileged: true` → `false`), so a minor bump is the safer signal to chart consumers. Happy to make it `0.21.1` if maintainers prefer.

`appVersion` is unchanged at `1.31.0.9` — no image change is involved.

## Notes

- The `README.md` version badge is helm-docs generated; only the badge is updated to match. The values table there is separately stale (it never listed `lbl.securityContext.*`) and is left alone to keep this diff focused.
- Verified `amd-gpu-helm-0.22.0` does not already exist as a release/tag.
- `helm lint helm/amd-gpu` passes (the missing `node-feature-discovery` dependency warning is pre-existing — it is an optional conditional dependency).