### PR TITLE
fix(labeller): sanitize "/" in GPU product name so labels apply

### DIFF
--- a/cmd/k8s-node-labeller/main.go
+++ b/cmd/k8s-node-labeller/main.go
@@ -208,7 +208,10 @@ var labelGenerators = map[string]func(map[string]map[string]interface{}) map[str
 	},
 	"product-name": func(gpus map[string]map[string]interface{}) map[string]string {
 		counts := map[string]int{}
-		replacer := strings.NewReplacer(" ", "_", "(", "", ")", "")
+		// "/" is invalid in both a label value and a label key name. The libdrm
+		// fallback returns marketing names such as "AMD Instinct MI250X / MI250",
+		// which otherwise make the whole label update fail validation.
+		replacer := strings.NewReplacer(" ", "_", "(", "", ")", "", "/", "_")
 
 		for _, v := range gpus {
 			prodnamePath := fmt.Sprintf("/sys/class/drm/card%d/device/product_name", v["card"])


### PR DESCRIPTION
Addresses the failure reported in #218.

## Root cause

On nodes with the in-tree `amdgpu` driver, sysfs `product_name` reads empty and the labeller falls back to libdrm, which returns a marketing name (`AMD Instinct MI250X / MI250`) rather than the board name sysfs provides (`AMD INSTINCT MI250 (MCM) OAM AC MBA`).

The replacer in `cmd/k8s-node-labeller/main.go` translates spaces and parentheses only, so the `/` survives. `createLabels` interpolates the product name into the counter key as well as the value, so both are rejected:

```
amd.com/gpu.product-name                                  : AMD_Instinct_MI250X_/_MI250   <- invalid value
beta.amd.com/gpu.product-name.AMD_Instinct_MI250X_/_MI250 : 8                             <- invalid key
```

Because `controller.go` writes all labels in a single `Update`, the whole patch is rejected and the node ends up with no `amd.com/gpu.*` labels.

## Change

Add `"/"` to the replacer. `AMD Instinct MI250X / MI250` now yields `AMD_Instinct_MI250X___MI250`, which passes `IsValidLabelValue` and `IsQualifiedName`. Board names read from sysfs are unchanged, so correctly labelled nodes see no churn.
